### PR TITLE
Fix the shop page after import

### DIFF
--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -145,7 +145,10 @@ class Rest_Server {
 	 */
 	public function run_xml_importer( WP_REST_Request $request ) {
 		$content_importer = new Content_Importer();
-		return $content_importer->import_remote_xml( $request );
+		$import =  $content_importer->import_remote_xml( $request );
+		set_transient( 'ti_tpc_should_flush_permalinks', 'yes', 12 * HOUR_IN_SECONDS );
+		
+		return $import;
 	}
 
 	/**

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -145,9 +145,9 @@ class Rest_Server {
 	 */
 	public function run_xml_importer( WP_REST_Request $request ) {
 		$content_importer = new Content_Importer();
-		$import =  $content_importer->import_remote_xml( $request );
+		$import           = $content_importer->import_remote_xml( $request );
 		set_transient( 'ti_tpc_should_flush_permalinks', 'yes', 12 * HOUR_IN_SECONDS );
-		
+
 		return $import;
 	}
 

--- a/templates-patterns-collection.php
+++ b/templates-patterns-collection.php
@@ -17,6 +17,7 @@
 
 add_action( 'admin_notices', 'ti_tpc_plugins_page_notice' );
 add_action( 'init', 'ti_tpc_load_textdomain' );
+add_action( 'init', 'ti_tpc_flush_premalinks' );
 
 /**
  * Plugins page notice if we don't have neve activated.
@@ -51,6 +52,22 @@ function ti_tpc_plugins_page_notice() {
 	$notice .= '</div>';
 
 	echo wp_kses_post( $notice );
+}
+
+/**
+ * Flush the permalinks after import
+ *
+ * @return bool
+ */
+function ti_tpc_flush_premalinks() {
+	$flash_rules = get_transient( 'ti_tpc_should_flush_permalinks' );
+	if ( $flash_rules !== 'yes' ){
+		return false;
+	}
+	
+	flush_rewrite_rules();
+	delete_transient( 'ti_tpc_should_flush_permalinks' );
+	return true;
 }
 
 /**

--- a/templates-patterns-collection.php
+++ b/templates-patterns-collection.php
@@ -61,10 +61,10 @@ function ti_tpc_plugins_page_notice() {
  */
 function ti_tpc_flush_premalinks() {
 	$flash_rules = get_transient( 'ti_tpc_should_flush_permalinks' );
-	if ( $flash_rules !== 'yes' ){
+	if ( $flash_rules !== 'yes' ) {
 		return false;
 	}
-	
+
 	flush_rewrite_rules();
 	delete_transient( 'ti_tpc_should_flush_permalinks' );
 	return true;


### PR DESCRIPTION
### Summary
Added a transient after importing the content from XML and then run rewrite_flush_rules function at init if the transient is set. 

### Test instructions
- Create a new instance of wp
- Install neve and this version of the plugin
- Try to import a starter site with WooCommerce


Closes Codeinwp/neve#1135
