### PR TITLE
fix: post meta not getting registered on 'init' hook

### DIFF
--- a/includes/Editor.php
+++ b/includes/Editor.php
@@ -26,9 +26,8 @@ class Editor {
 	 */
 	public function init() {
 		define( 'TPC_TEMPLATES_CLOUD_ENDPOINT', 'https://api.themeisle.com/templates-cloud/' );
-
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_block' ), 11 );
-		add_action( 'init', array( $this, 'register_post_meta' ), 11 );
+		$this->register_post_meta();
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue where post meta didn't get registered on init hook.