### PR TITLE
fix: proposed solution for Codeinwp/neve-pro-addon#1337

### DIFF
--- a/editor/src/extension.js
+++ b/editor/src/extension.js
@@ -68,7 +68,7 @@ const Exporter = () => {
 
 	useEffect( () => {
 		const metaKeys = window.tiTpc.metaKeys;
-		window.tiTpc.params.meta = Object.fromEntries( Object.entries( getMetaFields ).filter(( [key, value] ) => metaKeys.includes( key )) );
+		window.tiTpc.params.meta = Object.fromEntries( Object.entries( getMetaFields || {} ).filter(( [key, value] ) => metaKeys.includes( key )) );
 	}, [ getMetaFields ] );
 
 	const {


### PR DESCRIPTION
`Object.entries()` expects object as defined here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries

References: Codeinwp/neve-pro-addon#1337
Closes: Codeinwp/neve-pro-addon#1337