### PR TITLE
fix: filter woo pages on activation #95

### DIFF
--- a/includes/Importers/Plugin_Importer.php
+++ b/includes/Importers/Plugin_Importer.php
@@ -330,7 +330,27 @@ class Plugin_Importer {
 	private function maybe_provide_activation_help( $slug, $path ) {
 		if ( $slug === 'woocommerce' ) {
 			require_once( $path . '/includes/admin/wc-admin-functions.php' );
+
+			// hook into this filter to remove pages on activation of woocommerce
+			add_filter( 'woocommerce_create_pages', array( $this, 'woocommerce_activation_pages' ) );
 		}
+	}
+
+	/**
+	 * Filter pages from woocommerce activation.
+	 *
+	 * @param array $pages List of pages to be created on activation.
+	 * @return array
+	 */
+	public function woocommerce_activation_pages( $pages ) {
+		$filtered_pages = array( 'shop', 'cart', 'checkout', 'myaccount' );
+		foreach ( $filtered_pages as $filter ) {
+			if ( isset( $pages[ $filter ] ) ) {
+				unset( $pages[ $filter ] );
+			}
+		}
+
+		return $pages;
 	}
 
 	/**

--- a/languages/templates-patterns-collection.pot
+++ b/languages/templates-patterns-collection.pot
@@ -1,5 +1,5 @@
 # Copyright (C) 2021 ThemeIsle
-# This file is distributed under the same license as the Templates Patterns Collection plugin.
+# This file is distributed under the GPLv3.
 msgid ""
 msgstr ""
 "Project-Id-Version: Templates Patterns Collection 1.1.10\n"
@@ -9,9 +9,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-05-13T16:59:31+00:00\n"
+"POT-Creation-Date: 2021-05-24T14:06:55+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.4.0\n"
+"X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: templates-patterns-collection\n"
 
 #. Plugin Name of the plugin
@@ -30,11 +30,16 @@ msgstr ""
 msgid "https://themeisle.com"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:72
+#: dist/templates-patterns-collection/includes/Admin.php:73
 #: includes/Admin.php:70
 #: includes/Admin.php:71
 msgid "Starter Sites"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:82
+#: dist/templates-patterns-collection/includes/Elementor.php:75
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:398
 #: includes/Admin.php:80
 #: includes/Elementor.php:75
 #: includes/TI_Beaver.php:398
@@ -42,215 +47,298 @@ msgid "My Library"
 msgstr ""
 
 #. translators: %s - Theme name
+#: dist/templates-patterns-collection/includes/Admin.php:155
 #: includes/Admin.php:153
 msgid "Choose from multiple unique demos, specially designed for you, that can be installed with a single click. You just need to choose your favorite, and we will take care of everything else."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:247
 #: includes/Admin.php:244
 msgid "Great news!  Now you can export your own custom designs to the cloud and then reuse them on other sites."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:248
 #: includes/Admin.php:245
 msgid "Open %s"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:345
 #: includes/Admin.php:342
 msgid "Hi! We've noticed you were using a child theme of Zelle before. To make your transition easier, we can help you keep the same homepage settings you had before but in original Zelle's style, by converting it into an Elementor template."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:375
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:408
 #: includes/Admin.php:372
 #: includes/TI_Beaver.php:408
-#: assets/build/app.js:10
+#: assets/build/app.js:4665
 #: assets/src/Components/StarterSiteCard.js:60
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/StarterSiteCard.js:60
 msgid "Preview"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:376
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:409
 #: includes/Admin.php:373
 #: includes/TI_Beaver.php:409
-#: assets/build/app.js:10
+#: assets/build/app.js:4402
+#: assets/build/app.js:4669
 #: assets/src/Components/PreviewFrame.js:102
 #: assets/src/Components/StarterSiteCard.js:68
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/PreviewFrame.js:102
+#: dist/templates-patterns-collection/assets/src/Components/StarterSiteCard.js:68
 msgid "Import"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:377
 #: includes/Admin.php:374
 msgid "Get the PRO version!"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:378
 #: includes/Admin.php:375
 msgid "Importing"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:379
+#: dist/templates-patterns-collection/includes/Elementor.php:81
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:387
 #: includes/Admin.php:376
 #: includes/Elementor.php:81
 #: includes/TI_Beaver.php:387
-#: assets/build/app.js:2
+#: assets/build/app.js:3971
 #: assets/src/Components/Migration.js:165
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:165
 msgid "Cancel"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:380
 #: includes/Admin.php:377
 msgid "Loading"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:381
 #: includes/Admin.php:378
-#: assets/build/app.js:2
-#: assets/build/app.js:10
+#: assets/build/app.js:3284
+#: assets/build/app.js:3985
 #: assets/src/Components/ImportModal.js:603
 #: assets/src/Components/Migration.js:198
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:652
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:198
 msgid "View Website"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:382
 #: includes/Admin.php:379
-#: assets/build/app.js:10
+#: assets/build/app.js:3288
 #: assets/src/Components/ImportModal.js:613
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:662
 msgid "Add your own content"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:383
 #: includes/Admin.php:380
-#: assets/build/app.js:10
+#: assets/build/app.js:3281
 #: assets/src/Components/ImportModal.js:594
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:643
 msgid "Back to Sites Library"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:384
 #: includes/Admin.php:381
 msgid "Note"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:385
 #: includes/Admin.php:382
 msgid "Advanced Options"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:386
 #: includes/Admin.php:383
-#: assets/build/app.js:10
+#: assets/build/app.js:3023
 #: assets/src/Components/ImportModal.js:272
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:286
 msgid "Plugins"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:387
 #: includes/Admin.php:384
 msgid "General"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:388
 #: includes/Admin.php:385
 msgid "Keep current layout"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:389
+#: dist/templates-patterns-collection/includes/Elementor.php:96
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:421
 #: includes/Admin.php:386
 #: includes/Elementor.php:96
 #: includes/TI_Beaver.php:421
 msgid "Search"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:390
 #: includes/Admin.php:387
-#: assets/build/app.js:10
+#: assets/build/app.js:2966
 #: assets/src/Components/ImportModal.js:200
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:203
 msgid "Content"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:391
 #: includes/Admin.php:388
-#: assets/build/app.js:10
+#: assets/build/app.js:2970
 #: assets/src/Components/ImportModal.js:204
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:207
 msgid "Customizer"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:392
 #: includes/Admin.php:389
-#: assets/build/app.js:10
+#: assets/build/app.js:2974
 #: assets/src/Components/ImportModal.js:208
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:211
 msgid "Widgets"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:393
 #: includes/Admin.php:390
 msgid "We recommend you backup your website content before attempting a full site import."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:394
 #: includes/Admin.php:391
 msgid "Due to copyright issues, some of the demo images will not be imported and will be replaced by placeholder images."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:395
 #: includes/Admin.php:392
 msgid "Some of the demo images will not be imported and will be replaced by placeholder images."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:396
 #: includes/Admin.php:393
 msgid "Here is our own collection of related images you can use for your site."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:397
 #: includes/Admin.php:394
-#: assets/build/app.js:8
+#: assets/build/app.js:3261
 #: assets/src/Components/ImportModal.js:542
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:591
 msgid "Content was successfully imported. Enjoy your new site!"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:398
 #: includes/Admin.php:395
 msgid "Available in the PRO version"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:399
 #: includes/Admin.php:396
 msgid "Copy error code"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:400
 #: includes/Admin.php:397
 msgid "Download error log"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:401
 #: includes/Admin.php:398
 msgid "To import this demo you have to install the following plugins:"
 msgstr ""
 
 #. translators: 1 - 'here'.
+#: dist/templates-patterns-collection/includes/Admin.php:404
 #: includes/Admin.php:401
 msgid "It seems that Rest API is not working properly on your website. Read about how you can fix it %1$s."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:405
 #: includes/Admin.php:402
 msgid "here"
 msgstr ""
 
 #. translators: 1 - 'get in touch'.
+#: dist/templates-patterns-collection/includes/Admin.php:409
 #: includes/Admin.php:406
 msgid "Hi! It seems there is a configuration issue with your server that's causing the import to fail. Please %1$s with us with the error code below, so we can help you fix this."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:410
+#: dist/templates-patterns-collection/includes/Admin.php:420
 #: includes/Admin.php:407
 #: includes/Admin.php:417
 msgid "get in touch"
 msgstr ""
 
 #. translators: 1 - 'troubleshooting guide'.
+#: dist/templates-patterns-collection/includes/Admin.php:414
 #: includes/Admin.php:411
 msgid "Hi! It seems there is a configuration issue with your server that's causing the import to fail. Take a look at our %1$s to see if any of the proposed solutions work."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Admin.php:415
 #: includes/Admin.php:412
 msgid "troubleshooting guide"
 msgstr ""
 
 #. translators: 1 - 'get in touch'.
+#: dist/templates-patterns-collection/includes/Admin.php:419
 #: includes/Admin.php:416
 msgid "If none of the solutions in the guide work, please %1$s with us with the error code below, so we can help you fix this."
 msgstr ""
 
 #. translators: %s - 'WP_Filesystem'.
+#: dist/templates-patterns-collection/includes/Admin.php:424
 #: includes/Admin.php:421
 msgid "It seems that %s is not available. You can contact your site administrator or hosting provider to help you enable it."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:59
+#: dist/templates-patterns-collection/includes/Elementor.php:79
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:402
 #: includes/Elementor.php:59
 #: includes/Elementor.php:79
 #: includes/TI_Beaver.php:402
 msgid "Save to %s"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:60
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:382
 #: includes/Elementor.php:60
 #: includes/TI_Beaver.php:382
 msgid "Save Templates"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:61
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:383
 #: includes/Elementor.php:61
 #: includes/TI_Beaver.php:383
 msgid "Template Name"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:62
+#: dist/templates-patterns-collection/includes/Elementor.php:107
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:384
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:478
 #: includes/Elementor.php:62
 #: includes/Elementor.php:107
 #: includes/TI_Beaver.php:384
@@ -258,6 +346,10 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:63
+#: dist/templates-patterns-collection/includes/Elementor.php:100
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:385
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:426
 #: includes/Elementor.php:63
 #: includes/Elementor.php:100
 #: includes/TI_Beaver.php:385
@@ -265,204 +357,279 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:64
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:386
 #: includes/Elementor.php:64
 #: includes/TI_Beaver.php:386
 msgid "Automatically sync to the cloud"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:65
 #: includes/Elementor.php:65
 msgid "Template Saved."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:66
 #: includes/Elementor.php:66
 msgid "Template Published."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:67
 #: includes/Elementor.php:67
 msgid "Template Unpublished."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:70
 #: includes/Elementor.php:70
 msgid "Import from %s"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:72
 #: includes/Elementor.php:72
 msgid "Add Template from %s:"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:74
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:397
 #: includes/Elementor.php:74
 #: includes/TI_Beaver.php:397
 msgid "Page Templates"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:78
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:401
 #: includes/Elementor.php:78
 #: includes/TI_Beaver.php:401
 msgid "Sync Library"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:80
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:404
 #: includes/Elementor.php:80
 #: includes/TI_Beaver.php:404
-#: assets/build/app.js:2
-#: assets/build/app.js:10
+#: assets/build/app.js:447
+#: assets/build/app.js:3683
+#: assets/build/app.js:3971
+#: assets/build/app.js:4221
+#: assets/build/app.js:4380
 #: assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js:206
 #: assets/src/Components/InstallModal.js:163
 #: assets/src/Components/Migration.js:161
 #: assets/src/Components/OnboardingContent.js:153
 #: assets/src/Components/PreviewFrame.js:54
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js:206
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:163
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:161
+#: dist/templates-patterns-collection/assets/src/Components/OnboardingContent.js:153
+#: dist/templates-patterns-collection/assets/src/Components/PreviewFrame.js:54
 msgid "Close"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:82
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:405
 #: includes/Elementor.php:82
 #: includes/TI_Beaver.php:405
-#: assets/build/app.js:2
+#: assets/build/app.js:859
 #: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:183
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:183
 msgid "Edit"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:83
 #: includes/Elementor.php:83
 msgid "Duplicate"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:84
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:406
 #: includes/Elementor.php:84
 #: includes/TI_Beaver.php:406
 msgid "Delete"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:85
 #: includes/Elementor.php:85
 msgid "Insert"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:86
 #: includes/Elementor.php:86
 msgid "Back to Library"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:89
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:412
 #: includes/Elementor.php:89
 #: includes/TI_Beaver.php:412
 msgid "Sort by"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:91
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:414
 #: includes/Elementor.php:91
 #: includes/TI_Beaver.php:414
 msgid "Name"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:92
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:415
 #: includes/Elementor.php:92
 #: includes/TI_Beaver.php:415
 msgid "Date"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:93
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:416
 #: includes/Elementor.php:93
 #: includes/TI_Beaver.php:416
 msgid "Last Modified"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:94
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:417
 #: includes/Elementor.php:94
 #: includes/TI_Beaver.php:417
 msgid "Actions"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:97
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:422
 #: includes/Elementor.php:97
 #: includes/TI_Beaver.php:422
 msgid "Search Templates"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:101
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:427
 #: includes/Elementor.php:101
 #: includes/TI_Beaver.php:427
 msgid "Save your page to %s"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:102
 #: includes/Elementor.php:102
 msgid "Enter Template Name"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:103
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:428
 #: includes/Elementor.php:103
 #: includes/TI_Beaver.php:428
 msgid "Screenshot URL"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:104
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:429
 #: includes/Elementor.php:104
 #: includes/TI_Beaver.php:429
 msgid "Site Slug"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:105
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:430
 #: includes/Elementor.php:105
 #: includes/TI_Beaver.php:430
 msgid "Publish"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Elementor.php:106
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:431
 #: includes/Elementor.php:106
 #: includes/TI_Beaver.php:431
 msgid "Unpublish"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Sites_Listing.php:46
+#: dist/templates-patterns-collection/includes/Sites_Listing.php:56
 #: includes/Sites_Listing.php:46
 #: includes/Sites_Listing.php:56
 msgid "Want to keep using Zelle's homepage?"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/Sites_Listing.php:47
+#: dist/templates-patterns-collection/includes/Sites_Listing.php:57
 #: includes/Sites_Listing.php:47
 #: includes/Sites_Listing.php:57
 msgid "Hi! We've noticed you were using Zelle before. To make your transition easier, we can help you keep the same beautiful homepage you had before, by converting it into an Elementor template. This option will also import your homepage content."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:35
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:37
 #: includes/TI_Beaver.php:35
 #: includes/TI_Beaver.php:37
 msgid "Templates Cloud"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:36
 #: includes/TI_Beaver.php:36
 msgid "Templates Cloud by Neve."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:388
 #: includes/TI_Beaver.php:388
 msgid "Import Failed"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:389
 #: includes/TI_Beaver.php:389
 msgid "Export Failed"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:393
 #: includes/TI_Beaver.php:393
 msgid "No templates available. Add a new one?"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:394
 #: includes/TI_Beaver.php:394
 msgid "Are you sure you want to delete this template?"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:395
 #: includes/TI_Beaver.php:395
 msgid "This template is synced to a page."
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:403
 #: includes/TI_Beaver.php:403
 msgid "Update"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:407
 #: includes/TI_Beaver.php:407
 msgid "Deleting"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:418
 #: includes/TI_Beaver.php:418
 msgid "List View"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:419
 #: includes/TI_Beaver.php:419
 msgid "Grid View"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:423
 #: includes/TI_Beaver.php:423
 msgid "Clear search query"
 msgstr ""
 
+#: dist/templates-patterns-collection/includes/TI_Beaver.php:449
 #: includes/TI_Beaver.php:449
 msgid "Save to Neve Cloud"
 msgstr ""
 
+#: dist/templates-patterns-collection/templates-patterns-collection.php:42
 #: templates-patterns-collection.php:42
 msgid "You need to have %1$s installed and activated to use %2$s."
 msgstr ""
 
 #. translators: %s Neve theme name.
+#: dist/templates-patterns-collection/templates-patterns-collection.php:50
 #: templates-patterns-collection.php:50
 msgid "Install and Activate %s"
 msgstr ""
@@ -475,280 +642,408 @@ msgstr ""
 msgid "With Neve, you can choose from multiple unique demos, specially designed for you, that can be installed with a single click. You just need to choose your favorite, and we will take care of everything else."
 msgstr ""
 
-#. translators: %s: Error message.
-#: assets/build/app.js:2
-#: assets/src/Components/InstallModal.js:31
-msgid "An error has ocurred: %s"
+#: assets/build/app.js:425
+#: assets/build/app.js:4691
+#: assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js:155
+#: assets/src/Components/StarterSiteCard.js:103
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js:155
+#: dist/templates-patterns-collection/assets/src/Components/StarterSiteCard.js:103
+msgid "Premium"
 msgstr ""
 
-#. translators: %s: Error message.
-#: assets/build/app.js:2
-#: assets/src/Components/InstallModal.js:67
-msgid "Could not activate theme."
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/InstallModal.js:89
-msgid "Install and Activate Neve"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/InstallModal.js:102
-msgid "Logo"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/InstallModal.js:116
-msgid "In order to import the starter site, Neve theme has to be installed and activated. Click the button below to install and activate Neve"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/InstallModal.js:52
-msgid "Could not install theme."
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/InstallModal.js:147
-msgid "Install and Activate"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/InstallModal.js:151
-msgid "Activate"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/ImportModalError.js:26
-msgid "Error code"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/ImportModalError.js:31
-msgid "Error log"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/Migration.js:82
-#: assets/src/Components/Migration.js:240
-msgid "Migrate"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/Migration.js:141
-msgid "Migrating"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/Migration.js:189
-msgid "Edit Content"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/Migration.js:177
-msgid "Start Migration"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/Migration.js:260
-msgid "Dismissed"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/Migration.js:269
-msgid "Dismiss"
-msgstr ""
-
-#: assets/build/app.js:2
-#: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:210
-msgid "An error occurred!"
-msgstr ""
-
-#: assets/build/app.js:2
+#: assets/build/app.js:840
 #: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:142
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:142
 msgid "Import done!"
 msgstr ""
 
-#: assets/build/app.js:2
+#: assets/build/app.js:842
 #: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:149
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:149
 msgid "Template was successfully imported!"
 msgstr ""
 
-#: assets/build/app.js:2
+#: assets/build/app.js:842
 #: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:153
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:153
 msgid "Templates were successfully imported!"
 msgstr ""
 
-#: assets/build/app.js:2
+#: assets/build/app.js:856
 #: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:174
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:174
 msgid "Visit"
 msgstr ""
 
-#. translators: name of starter site
-#: assets/build/app.js:4
-#: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:277
-msgid "Import the %s template"
-msgstr ""
-
-#. translators: name of template
-#: assets/build/app.js:6
-#: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:282
-msgid "Import all templates from %s"
+#: assets/build/app.js:874
+#: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:210
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:210
+msgid "An error occurred!"
 msgstr ""
 
 #. translators: %s  the name of the template
-#: assets/build/app.js:8
+#: assets/build/app.js:894
 #: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:246
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:246
 msgid "The %s template will be imported as a page into your site. This import will install & activate the page builder plugin if not already installed."
 msgstr ""
 
 #. translators: %s  the name of the template
-#: assets/build/app.js:8
+#: assets/build/app.js:894
 #: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:252
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:252
 msgid "All the templates that are included in this starter site, will be imported as pages. This import will install & activate the page builder plugin if not already installed."
 msgstr ""
 
-#: assets/build/app.js:8
+#. translators: name of starter site
+#: assets/build/app.js:913
+#: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:277
+#: dist/templates-patterns-collection/assets/build/app.js:4
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:277
+msgid "Import the %s template"
+msgstr ""
+
+#. translators: name of template
+#: assets/build/app.js:915
+#: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:282
+#: dist/templates-patterns-collection/assets/build/app.js:6
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:282
+msgid "Import all templates from %s"
+msgstr ""
+
+#: assets/build/app.js:924
 #: assets/src/Components/CloudLibrary/ImportTemplatesModal.js:302
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/CloudLibrary/ImportTemplatesModal.js:302
 msgid "I want to import the entire site"
 msgstr ""
 
-#: assets/build/app.js:8
-#: assets/src/utils/common.js:27
-msgid "Business"
+#: assets/build/app.js:2350
+#: assets/build/app.js:2379
+#: assets/build/app.js:2460
+#: assets/src/Components/EditorSelector.js:30
+#: assets/src/Components/EditorSelector.js:70
+#: assets/src/Components/EditorTabs.js:42
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/EditorSelector.js:30
+#: dist/templates-patterns-collection/assets/src/Components/EditorSelector.js:70
+#: dist/templates-patterns-collection/assets/src/Components/EditorTabs.js:42
+msgid "Builder Logo"
 msgstr ""
 
-#: assets/build/app.js:8
-#: assets/src/utils/common.js:28
-msgid "Ecommerce"
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/utils/common.js:29
-msgid "Fashion"
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/utils/common.js:30
-msgid "Blogging"
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/utils/common.js:31
-msgid "Photography"
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/Components/ImportStepper.js:8
-msgid "Installing Plugins"
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/Components/ImportStepper.js:13
-msgid "Importing Content"
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/Components/ImportStepper.js:18
-msgid "Importing Customizer Settings"
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/Components/ImportStepper.js:26
-msgid "Importing Widgets"
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/Components/ImportModal.js:427
-msgid "Something went wrong while installing the necessary plugins."
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/Components/ImportModal.js:431
-msgid "Something went wrong while importing the website content."
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/Components/ImportModal.js:435
-msgid "Something went wrong while updating the customizer settings."
-msgstr ""
-
-#: assets/build/app.js:8
-#: assets/src/Components/ImportModal.js:439
-msgid "Something went wrong while importing the widgets."
-msgstr ""
-
-#: assets/build/app.js:8
+#: assets/build/app.js:2854
+#: assets/build/app.js:2879
 #: assets/src/Components/ImportModal.js:61
 #: assets/src/Components/ImportModal.js:97
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:64
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:100
 msgid "Something went wrong while loading the site data. Please refresh the page and try again."
 msgstr ""
 
 #. translators: name of starter site
-#: assets/build/app.js:10
+#: assets/build/app.js:2958
 #: assets/src/Components/ImportModal.js:180
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:183
 msgid "Import %s as a complete site"
 msgstr ""
 
 #. translators: name of starter site
-#: assets/build/app.js:10
+#: assets/build/app.js:2960
 #: assets/src/Components/ImportModal.js:188
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:191
 msgid "Import the entire site including customizer options, pages, content and plugins."
 msgstr ""
 
-#: assets/build/app.js:10
+#: assets/build/app.js:2987
 #: assets/src/Components/ImportModal.js:222
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:236
 msgid "Import settings"
 msgstr ""
 
-#: assets/build/app.js:10
+#: assets/build/app.js:3179
+#: assets/src/Components/ImportModal.js:427
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:472
+msgid "Something went wrong while installing the necessary plugins."
+msgstr ""
+
+#: assets/build/app.js:3180
+#: assets/src/Components/ImportModal.js:431
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:476
+msgid "Something went wrong while importing the website content."
+msgstr ""
+
+#: assets/build/app.js:3181
+#: assets/src/Components/ImportModal.js:435
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:480
+msgid "Something went wrong while updating the customizer settings."
+msgstr ""
+
+#: assets/build/app.js:3182
+#: assets/src/Components/ImportModal.js:439
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:484
+msgid "Something went wrong while importing the widgets."
+msgstr ""
+
+#: assets/build/app.js:3267
 #: assets/src/Components/ImportModal.js:562
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:611
 msgid "I want to import just the templates"
 msgstr ""
 
-#: assets/build/app.js:10
+#: assets/build/app.js:3275
 #: assets/src/Components/ImportModal.js:580
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:629
 msgid "Import entire site"
 msgstr ""
 
-#: assets/build/app.js:10
-#: assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js:155
-#: assets/src/Components/StarterSiteCard.js:103
-msgid "Premium"
+#: assets/build/app.js:3358
+#: assets/src/Components/ImportModalError.js:26
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/ImportModalError.js:26
+msgid "Error code"
 msgstr ""
 
-#: assets/build/app.js:10
-#: assets/src/Components/StarterSiteCard.js:81
-msgid "View Pages"
+#: assets/build/app.js:3358
+#: assets/src/Components/ImportModalError.js:31
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/ImportModalError.js:31
+msgid "Error log"
 msgstr ""
 
-#: assets/build/app.js:10
+#: assets/build/app.js:3448
+#: assets/src/Components/ImportStepper.js:8
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportStepper.js:13
+msgid "Installing Plugins"
+msgstr ""
+
+#: assets/build/app.js:3453
+#: assets/src/Components/ImportStepper.js:13
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportStepper.js:18
+msgid "Importing Content"
+msgstr ""
+
+#: assets/build/app.js:3458
+#: assets/src/Components/ImportStepper.js:18
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportStepper.js:23
+msgid "Importing Customizer Settings"
+msgstr ""
+
+#: assets/build/app.js:3463
+#: assets/src/Components/ImportStepper.js:26
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportStepper.js:31
+msgid "Importing Widgets"
+msgstr ""
+
+#. translators: %s: Error message.
+#: assets/build/app.js:3587
+#: assets/src/Components/InstallModal.js:31
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:31
+msgid "An error has ocurred: %s"
+msgstr ""
+
+#: assets/build/app.js:3604
+#: assets/src/Components/InstallModal.js:52
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:52
+msgid "Could not install theme."
+msgstr ""
+
+#. translators: %s: Error message.
+#: assets/build/app.js:3614
+#: assets/src/Components/InstallModal.js:67
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:67
+msgid "Could not activate theme."
+msgstr ""
+
+#: assets/build/app.js:3634
+#: assets/src/Components/InstallModal.js:89
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:89
+msgid "Install and Activate Neve"
+msgstr ""
+
+#: assets/build/app.js:3648
+#: assets/src/Components/InstallModal.js:102
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:102
+msgid "Logo"
+msgstr ""
+
+#: assets/build/app.js:3659
+#: assets/src/Components/InstallModal.js:116
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:116
+msgid "In order to import the starter site, Neve theme has to be installed and activated. Click the button below to install and activate Neve"
+msgstr ""
+
+#: assets/build/app.js:3676
+#: assets/src/Components/InstallModal.js:147
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:147
+msgid "Install and Activate"
+msgstr ""
+
+#: assets/build/app.js:3676
+#: assets/src/Components/InstallModal.js:151
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/InstallModal.js:151
+msgid "Activate"
+msgstr ""
+
+#: assets/build/app.js:3942
+#: assets/build/app.js:4014
+#: assets/src/Components/Migration.js:82
+#: assets/src/Components/Migration.js:240
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:82
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:240
+msgid "Migrate"
+msgstr ""
+
+#: assets/build/app.js:3964
+#: assets/src/Components/Migration.js:141
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:141
+msgid "Migrating"
+msgstr ""
+
+#: assets/build/app.js:3976
+#: assets/src/Components/Migration.js:177
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:177
+msgid "Start Migration"
+msgstr ""
+
+#: assets/build/app.js:3982
+#: assets/src/Components/Migration.js:189
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:189
+msgid "Edit Content"
+msgstr ""
+
+#: assets/build/app.js:4025
+#: assets/src/Components/Migration.js:260
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:260
+msgid "Dismissed"
+msgstr ""
+
+#: assets/build/app.js:4029
+#: assets/src/Components/Migration.js:269
+#: dist/templates-patterns-collection/assets/build/app.js:2
+#: dist/templates-patterns-collection/assets/src/Components/Migration.js:269
+msgid "Dismiss"
+msgstr ""
+
+#: assets/build/app.js:4230
+#: assets/src/Components/OnboardingContent.js:171
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/OnboardingContent.js:171
+msgid "No results found"
+msgstr ""
+
+#: assets/build/app.js:4385
 #: assets/src/Components/PreviewFrame.js:62
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/PreviewFrame.js:62
 msgid "Previous"
 msgstr ""
 
-#: assets/build/app.js:10
+#: assets/build/app.js:4390
 #: assets/src/Components/PreviewFrame.js:74
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/PreviewFrame.js:74
 msgid "Next"
 msgstr ""
 
-#: assets/build/app.js:10
+#: assets/build/app.js:4398
 #: assets/src/Components/PreviewFrame.js:91
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/PreviewFrame.js:91
 msgid "Upgrade and Import"
 msgstr ""
 
-#: assets/build/app.js:10
+#: assets/build/app.js:4542
 #: assets/src/Components/Search.js:102
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/Search.js:102
 msgid "Search for a starter site"
 msgstr ""
 
-#: assets/build/app.js:10
-#: assets/src/Components/EditorSelector.js:30
-#: assets/src/Components/EditorSelector.js:70
-#: assets/src/Components/EditorTabs.js:42
-msgid "Builder Logo"
+#: assets/build/app.js:4677
+#: assets/src/Components/StarterSiteCard.js:81
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/StarterSiteCard.js:81
+msgid "View Pages"
 msgstr ""
 
-#: assets/build/app.js:10
-#: assets/src/Components/OnboardingContent.js:171
-msgid "No results found"
+#: assets/build/app.js:5323
+#: assets/src/utils/common.js:27
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/utils/common.js:27
+msgid "Business"
+msgstr ""
+
+#: assets/build/app.js:5323
+#: assets/src/utils/common.js:28
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/utils/common.js:28
+msgid "Ecommerce"
+msgstr ""
+
+#: assets/build/app.js:5323
+#: assets/src/utils/common.js:29
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/utils/common.js:29
+msgid "Fashion"
+msgstr ""
+
+#: assets/build/app.js:5323
+#: assets/src/utils/common.js:30
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/utils/common.js:30
+msgid "Blogging"
+msgstr ""
+
+#: assets/build/app.js:5323
+#: assets/src/utils/common.js:31
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/utils/common.js:31
+msgid "Photography"
+msgstr ""
+
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/build/app.js:10
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:220
+#: dist/templates-patterns-collection/assets/src/Components/ImportStepper.js:8
+msgid "Cleanup previous Import"
+msgstr ""
+
+#: dist/templates-patterns-collection/assets/build/app.js:8
+#: dist/templates-patterns-collection/assets/src/Components/ImportModal.js:468
+msgid "Something went wrong while cleaning the previous import."
 msgstr ""


### PR DESCRIPTION
### Summary
Disable import of default woo pages on plugin install.
Only import pages from xml

### Test instructions
When first importing a Store with WooCommerce dependency for the first time only one Shop page should exist.

Closes #95
