### PR TITLE
fix: solves notice on WP5.8 Codeinwp/neve#2954

### DIFF
--- a/includes/Editor.php
+++ b/includes/Editor.php
@@ -38,6 +38,15 @@ class Editor {
 	public function register_block() {
 		$deps = require( TIOB_PATH . 'editor/build/index.asset.php' );
 
+		$screen = get_current_screen();
+		if ( ! isset( $screen->id ) ) {
+			return;
+		}
+
+		if ( $screen->id === 'widgets' ) {
+			return;
+		}
+
 		wp_register_script(
 			$this->handle,
 			TIOB_URL . 'editor/build/index.js',


### PR DESCRIPTION
### Summary
I've changed the enqueue for the new Widgets page in WP 5.8
The Template Patterns uses a Gutenberg Block for adding content to a Post, however using the same block inside Widgets does not make sense since it relies on `getEditedPostAttribute` witch is not available on the widgets page and enqueuing the script with `wp-edit-post` will trigger a Notice. Another reason for excluding the block from widgets is the fact that we don't have any widgets templates.

References: Codeinwp/neve/pull/2957

### Test instructions
See Codeinwp/neve#2954 for testing instructions.


Closes Codeinwp/neve#2954.
