### PR TITLE
chore: fix WP-CLI commands [ref: Codeinwp/neve-pro-addon#1532]

### DIFF
--- a/includes/Importers/Content_Importer.php
+++ b/includes/Importers/Content_Importer.php
@@ -249,7 +249,7 @@ class Content_Importer {
 	/**
 	 * Maybe bust cache for elementor plugin.
 	 */
-	private function maybe_bust_elementor_cache() {
+	public function maybe_bust_elementor_cache() {
 		if ( ! class_exists( '\Elementor\Plugin' ) ) {
 			return;
 		}

--- a/includes/Importers/Plugin_Importer.php
+++ b/includes/Importers/Plugin_Importer.php
@@ -172,7 +172,7 @@ class Plugin_Importer {
 		}
 
 		// User doesn't have permissions.
-		if ( ! current_user_can( 'install_plugins' ) ) {
+		if ( ! current_user_can( 'install_plugins' ) && ! class_exists( 'WP_CLI' ) ) {
 			return false;
 		}
 
@@ -307,7 +307,7 @@ class Plugin_Importer {
 		}
 
 		// User doesn't have permissions.
-		if ( ! current_user_can( 'activate_plugins' ) ) {
+		if ( ! current_user_can( 'activate_plugins' ) && ! class_exists( 'WP_CLI' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Summary
Fixes WP-CLI commands used to import websites.
<!-- Please describe the changes you made. -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Run `wp themeisle-si list`. This should list all the starter sites;
- Run `wp themeisle-si import <slug>` to import any statr

<!-- Issues that this pull request closes. -->
Ref: Codeinwp/neve-pro-addon#1532.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
