### PR TITLE
Replace add_post_meta with update_post_meta

### DIFF
--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -540,7 +540,7 @@ class WP_Import extends WP_Importer {
 						) ) {
 							$value = $this->replace_image_urls( $value );
 						}
-						add_post_meta( $post_id, $key, $value );
+						update_post_meta( $post_id, $key, $value );
 						do_action( 'import_post_meta', $post_id, $key, $value );
 						// if the post has a featured image, take note of this in case of remap
 						if ( '_thumbnail_id' == $key ) {


### PR DESCRIPTION
### Summary
Replace add_post_meta function with update_post_meta function to avoid duplicate meta keys.

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Import Constructions company starter site.
- Open the About page.
- Publish and there shouldn't be any error, unlike before.

<!-- Issues that this pull request closes. -->
Closes #120 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
