### PR TITLE
Feat/widget reassign

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           php-version: '7.1'
           extensions: simplexml, mysql
-          tools: phpunit:7.5.15, phpunit-polyfills
+          tools: phpunit-polyfills
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Install WordPress Test Suite

--- a/assets/src/Components/Header.js
+++ b/assets/src/Components/Header.js
@@ -14,8 +14,8 @@ import { addUrlHash, getTabHash } from '../utils/common';
 
 const TabNavigation = ( { setCurrentTab, currentTab, isFetching } ) => {
 	const buttons = {
-		starterSites: __( 'Starter Sites', 'neve' ),
-		pageTemplates: __( 'Page Templates', 'neve' ),
+		starterSites: __( 'Starter Sites', 'templates-patterns-collection' ),
+		pageTemplates: __( 'Page Templates', 'templates-patterns-collection' ),
 	};
 
 	const [ isSyncing, setSyncing ] = useState( false );
@@ -36,7 +36,7 @@ const TabNavigation = ( { setCurrentTab, currentTab, isFetching } ) => {
 		tiobDash.license.tier &&
 		tiobDash.license.tier === 3
 	) {
-		buttons.library = __( 'My Library', 'neve' );
+		buttons.library = __( 'My Library', 'templates-patterns-collection' );
 	}
 
 	const onHashChanged = () => {
@@ -122,7 +122,12 @@ const Header = ( {
 							{ ! tiobDash.brandedTheme && (
 								<Icon icon={ Logo } />
 							) }
-							<span>{ __( 'Templates Cloud', 'neve' ) }</span>
+							<span>
+								{ __(
+									'Templates Cloud',
+									'templates-patterns-collection'
+								) }
+							</span>
 						</h2>
 						<TabNavigation
 							setCurrentTab={ setCurrentTab }

--- a/assets/src/Components/ImportModalMock.js
+++ b/assets/src/Components/ImportModalMock.js
@@ -22,6 +22,7 @@ const ImportModalMock = ( {} ) => (
 				<ol>
 					<li />
 					<li />
+					<li />
 				</ol>
 			</div>
 

--- a/assets/src/Components/ImportModalNote.js
+++ b/assets/src/Components/ImportModalNote.js
@@ -15,7 +15,7 @@ const ImportModalNote = ( { data, externalInstalled } ) => {
 					<span>
 						{ __(
 							'To import this demo you have to install the following plugins',
-							'neve'
+							'templates-patterns-collection'
 						) }
 					</span>
 				</h3>
@@ -46,7 +46,7 @@ const ImportModalNote = ( { data, externalInstalled } ) => {
 						<li>
 							{ __(
 								'Some of the demo images will not be imported and will be replaced by placeholder images.',
-								'neve'
+								'templates-patterns-collection'
 							) }
 						</li>
 					</Fragment>

--- a/assets/src/Components/ImportModalNote.js
+++ b/assets/src/Components/ImportModalNote.js
@@ -34,7 +34,13 @@ const ImportModalNote = ( { data, externalInstalled } ) => {
 						<li>
 							{ __(
 								'We recommend you backup your website content before attempting a full site import.',
-								'neve'
+								'templates-patterns-collection'
+							) }
+						</li>
+						<li>
+							{ __(
+								'Widgets will be moved to the Inactive Widgets sidebar and can be retrieved from there.',
+								'templates-patterns-collection'
 							) }
 						</li>
 						<li>

--- a/assets/src/Components/Migration.js
+++ b/assets/src/Components/Migration.js
@@ -46,7 +46,7 @@ const Migration = ( { data } ) => {
 					code: r.data || null,
 					message: __(
 						'Something went wrong while installing the necessary plugins.',
-						'neve'
+						'templates-patterns-collection'
 					),
 				} );
 				setMigrating( false );
@@ -62,7 +62,7 @@ const Migration = ( { data } ) => {
 						code: r.data || null,
 						message: __(
 							'Something went wrong while importing the website content.',
-							'neve'
+							'templates-patterns-collection'
 						),
 					} );
 					setMigrating( false );
@@ -104,7 +104,7 @@ const Migration = ( { data } ) => {
 										<h3>
 											{ __(
 												'The following plugins will be installed',
-												'neve'
+												'templates-patterns-collection'
 											) }
 											:
 										</h3>
@@ -130,7 +130,7 @@ const Migration = ( { data } ) => {
 							<p className="import-result">
 								{ __(
 									'Content was successfully imported. Enjoy your new site!',
-									'neve'
+									'templates-patterns-collection'
 								) }
 							</p>
 						) }
@@ -251,7 +251,7 @@ const Migration = ( { data } ) => {
 								setToast(
 									__(
 										'Something went wrong. Please reload the page and try again.',
-										'neve'
+										'templates-patterns-collection'
 									)
 								);
 								return false;

--- a/assets/src/Components/OnboardingContent.js
+++ b/assets/src/Components/OnboardingContent.js
@@ -139,7 +139,7 @@ const OnboardingContent = ( {
 				<p>
 					{ __(
 						'Starter sites could not be loaded. Please refresh and try again.',
-						'neve'
+						'templates-patterns-collection'
 					) }
 					{ isOnboarding && (
 						<Button
@@ -171,10 +171,11 @@ const OnboardingContent = ( {
 						{ __(
 							'No results found.',
 							'templates-patterns-collection'
-						) }&nbsp;
+						) }
+						&nbsp;
 						{ __(
 							'You can try a different search or use one of the categories below.',
-							'neve'
+							'templates-patterns-collection'
 						) }
 					</p>
 					<div className="tags">


### PR DESCRIPTION
### Summary
Reassign existing widgets to the inactive widgets sidebar upon doing a demo import.
<!-- Please describe the changes you made. -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add some widgets to your website;
- Import a demo that has widgets in the same sidebar;
- The previously added widgets should be moved to the Inactive Widgets Sidebar;
- Upon doing an import cleanup - without having the other toggles of the import on - your website should be restored to its previous state - widgets back in the sidebar.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve#3157.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
