### PR TITLE
remove upsell notice from gutenberg tab

### DIFF
--- a/assets/src/Components/StarterSites/Filters.js
+++ b/assets/src/Components/StarterSites/Filters.js
@@ -120,7 +120,7 @@ const Filters = ( {
 						onlyProSites={ onlyProBuilders }
 						count={ counted.builders }
 					/>
-					{ ! tiobDash.isValidLicense && (
+					{ ! tiobDash.isValidLicense && editor !== 'gutenberg' && (
 						<Notification
 							data={ tiobDash.upsellNotifications.upsell_1 }
 							editor={ editor }


### PR DESCRIPTION
### Summary

Remove upsell notification from gutenberg starter sites tab

### Test instructions
<!-- Describe how this pull request can be tested. -->

- When license is inactive or pro plugin is disabled, the upsell notice should not be shown

<!-- Issues that this pull request closes. -->
Closes #134 
<!-- Should look like this: `Closes #1, #2, #3.` . -->
