### PR TITLE
chore: added filter and method to allow changing to legacy

### DIFF
--- a/includes/Sites_Listing.php
+++ b/includes/Sites_Listing.php
@@ -72,9 +72,26 @@ class Sites_Listing {
 	 */
 	final public static function get_api_path() {
 		if ( defined( 'TPC_USE_STAGING' ) && TPC_USE_STAGING === true ) {
-			return ( defined( 'TPC_API_STAGING' ) && ! empty( TPC_API_STAGING ) ) ? TPC_API_STAGING : self::API;
+			return ( ( defined( 'TPC_API_STAGING' ) && ! empty( TPC_API_STAGING ) ) ? TPC_API_STAGING : self::API ) . self::add_query_args();
 		}
-		return self::API;
+		return self::API . self::add_query_args();
+	}
+
+	/**
+	 * Allows adding $_GET arguments to API path.
+	 *
+	 * @return string
+	 */
+	private static function add_query_args() {
+		$query_args   = array();
+		$allowed_keys = array(
+			'show-legacy-sites',
+		);
+		// filter all keys that are not in $allowed_keys since the filter can provide third parties access to the URL.
+		$query_args   = array_intersect_key( apply_filters( 'tpc_starter_api_query_filter', $query_args ), array_flip( $allowed_keys ) );
+		$query_string = http_build_query( $query_args );
+
+		return ( ! empty( $query_string ) ) ? '?' . $query_string : '';
 	}
 
 	/**


### PR DESCRIPTION
### Summary
This is linked to the changes in demo-exporter for this [PR#97](https://github.com/Codeinwp/demo-data-exporter/pull/97)
Also this will work with this plugin [Codeinwp/ti-starter-sites-legacy](https://github.com/Codeinwp/ti-starter-sites-legacy)

This PR allows for query arguments to be passed to the API path, it provides a filter that can be used to add more arguments, but it filters the final arguments to only allowed ones to prevent malicious use.

### Test instructions
1. Use this build version of the plugin
2. Install the [Codeinwp/ti-starter-sites-legacy](https://github.com/Codeinwp/ti-starter-sites-legacy) by going to the repository and clicking on Code > Download Zip. Install the plugin zip.
3. Add `define( 'TPC_USE_STAGING', true );` and `define( 'TPC_API_STAGING', 'https://staging.demosites.io/wp-json/demosites-api/sites' );` to use the staging version.
4. Initially only specified sites from [here](https://www.notion.so/themeisle/b0a8407b19844627a88717d81096eb94?v=b8a16bb91e094952af8c3b5f3b336bcf) should be visible.
5. When enabling `ti-starter-sites-legacy` all starter sites should be revealed.
6. On disabling `ti-starter-sites-legacy` the list should revert to only supported active sites.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/demo-data-exporter#95.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
