### PR TITLE
fix: reviews import on products #139

### DIFF
--- a/includes/Importers/Cleanup/Active_State.php
+++ b/includes/Importers/Cleanup/Active_State.php
@@ -21,6 +21,7 @@ class Active_State {
 	const TAGS_NSP        = 'tags';
 	const TERMS_NSP       = 'terms';
 	const POSTS_NSP       = 'posts';
+	const COMMENTS_NSP    = 'comments';
 	const ATTACHMENT_NSP  = 'attachment';
 	const FRONT_PAGE_NSP  = 'front_page_options';
 	const SHOP_PAGE_NSP   = 'shop_page_options';
@@ -56,6 +57,7 @@ class Active_State {
 				self::TAGS_NSP,
 				self::TERMS_NSP,
 				self::POSTS_NSP,
+				self::COMMENTS_NSP,
 				self::ATTACHMENT_NSP,
 				self::THEME_MODS_NSP,
 				self::MENUS_NSP,

--- a/includes/Importers/Cleanup/Manager.php
+++ b/includes/Importers/Cleanup/Manager.php
@@ -155,6 +155,11 @@ class Manager {
 				wp_delete_post( $post_id, true );
 			}
 		}
+		if ( isset( $state[ Active_State::COMMENTS_NSP ] ) ) {
+			foreach ( $state[ Active_State::COMMENTS_NSP ] as $comment_id ) {
+				wp_delete_comment( $comment_id, true );
+			}
+		}
 	}
 
 	/**

--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -509,7 +509,9 @@ class WP_Import extends WP_Importer {
 			if ( ! empty( $post['comments'] ) ) {
 				foreach ( $post['comments'] as $comment ) {
 					$comment['comment_post_ID'] = $post_id;
-					$comment_id                 = wp_insert_comment( $comment );
+					$comment['comment_meta']    = array_combine( array_column( $comment['commentmeta'], 'key' ), array_column( $comment['commentmeta'], 'value' ) );
+					unset( $comment['commentmeta'] );
+					$comment_id = wp_insert_comment( $comment );
 					if ( $comment_id === false ) {
 						$this->logger->log( "Could not import comment for {$post_id}." );
 						continue;

--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -506,6 +506,17 @@ class WP_Import extends WP_Importer {
 				$post['comments'] = array();
 			}
 			$post['comments'] = apply_filters( 'wp_import_post_comments', $post['comments'], $post_id, $post );
+			if ( ! empty( $post['comments'] ) ) {
+				foreach ( $post['comments'] as $comment ) {
+					$comment['comment_post_ID'] = $post_id;
+					$comment_id                 = wp_insert_comment( $comment );
+					if ( $comment_id === false ) {
+						$this->logger->log( "Could not import comment for {$post_id}." );
+						continue;
+					}
+					do_action( 'themeisle_cl_add_item_to_property_state', Active_State::COMMENTS_NSP, $comment_id );
+				}
+			}
 
 			if ( ! isset( $post['postmeta'] ) ) {
 				$post['postmeta'] = array();


### PR DESCRIPTION
### Summary
Added comment Import routine and cleanup method.
It looks like the comments were not imported previously.
This is also linked with the changes from here: https://github.com/Codeinwp/demo-data-exporter/pull/103

### Test instructions
1. Test using the https://github.com/Codeinwp/ti-starter-sites-legacy plugin, as the Shop is part of the Legacy sites now.
2. Add define( 'TPC_USE_STAGING', true ); and define( 'TPC_API_STAGING', 'https://staging.demosites.io/wp-json/demosites-api/sites' ); to use the staging version.
3. Import the Shop
4. Check that the reviews are imported and displayed correctly.

<!-- Issues that this pull request closes. -->
Closes #139.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
