### PR TITLE
chore: made text changes to upsells to help prevent confusion

### DIFF
--- a/assets/src/Components/EditorTabs.js
+++ b/assets/src/Components/EditorTabs.js
@@ -50,7 +50,9 @@ const EditorTabs = ( {
 						</span>
 						<span className="count">{ count[ key ] }</span>
 						{ onlyProSites.includes( key ) && (
-							<span className="pro-badge">PRO</span>
+							<span className="pro-badge">
+								{ __( 'Premium', 'templates-patterns-collection' ) }
+							</span>
 						) }
 					</a>
 				);

--- a/assets/src/scss/_editor-tabs.scss
+++ b/assets/src/scss/_editor-tabs.scss
@@ -26,7 +26,7 @@
 	align-items: center;
 	font-weight: 700;
 	text-decoration: none;
-	font-size: 15px;
+	font-size: 14px;
 	border-bottom: 3px solid transparent;
 	position: relative;
 	width: auto;
@@ -45,7 +45,7 @@
 
 	.pro-badge {
 	  margin-left: auto;
-	  font-size: 11px;
+	  font-size: 10px;
 	}
   }
 
@@ -104,7 +104,7 @@
   .editor-tabs {
 	a {
 	  width: auto;
-	  padding: 15px 20px 12px 5px;
+	  padding: 15px 10px 12px 5px;
 	}
   }
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -178,7 +178,7 @@ class Admin {
 
 		$notifications['upsell_1'] = array(
 			// We use these strings in Neve already so lets reuse the translations here.
-			'text' => esc_html__( 'Upgrade to the PRO version and get instant access to all Premium Starter Sites — including Expert Sites — and much more.', 'neve' ), //phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+			'text' => esc_html__( 'Purchase the Business plan or higher to get instant access to all Premium Starter Site Templates — including Expert Sites — and much more.', 'neve' ), //phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 			'cta'  => __( 'Get Neve PRO Now', 'neve' ), //phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 			'url'  => 'https://themeisle.com/themes/neve/upgrade/?utm_medium=nevedashboard&utm_source=templatecloud&utm_campaign=neve&utm_content=<builder_name>notice',
 		);


### PR DESCRIPTION
### Summary
Made some changes to the upsell messages to help prevent confusion

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this patch
- Check out the starter sites area in Neve options, it should now show "premium" on the builder tabs and the notification text should also be updated

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/1945
<!-- Should look like this: `Closes #1, #2, #3.` . -->
