### PR TITLE
fix: menu import for megamenu

### DIFF
--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -636,7 +636,7 @@ class WP_Import extends WP_Importer {
 		$args     = apply_filters( 'wp_import_nav_menu_item_args', $args, $this->base_blog_url );
 		$existing = wp_get_nav_menu_items( $menu_id );
 		foreach ( $existing as $existing_item ) {
-			if ( $args['menu-item-url'] === $existing_item->url ) {
+			if ( $args['menu-item-url'] === $existing_item->url && trim( $args['menu-item-title'] ) === $existing_item->title ) {
 				$this->logger->log( 'Menu item already exists.', 'success' );
 
 				return;


### PR DESCRIPTION
### Summary
On the mega menu, if you use the same link subsequent items would not get imported.
This was evident in this issue https://github.com/Codeinwp/demo-data-exporter/issues/92

### Test instructions
1. Use this build
2. Set `define( 'TPC_USE_STAGING', true );` and `define( 'TPC_API_STAGING', 'https://staging.demosites.io/wp-json/demosites-api/sites' );`
3. Import the Medicare SS
4. Check that all items from Mega Menu are imported
5. Check the same with the old version, subsequent columns were not imported.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/demo-data-exporter#92.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
