### PR TITLE
chore: removed archived editors and changed layout

### DIFF
--- a/assets/src/Components/CategoriesTabs.js
+++ b/assets/src/Components/CategoriesTabs.js
@@ -1,0 +1,55 @@
+import classnames from 'classnames';
+
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+const CategoriesTabs = ( {
+	categories,
+	count,
+	category,
+	setCurrentCategory,
+} ) => {
+	return (
+		<div className="editor-tabs">
+			{ Object.keys( categories ).map( ( key, index ) => {
+				if ( 1 > count[ key ] ) {
+					return null;
+				}
+				const classes = classnames( [
+					'tab',
+					key,
+					{ active: key === category },
+				] );
+				return (
+					<a
+						key={ index }
+						href="#"
+						className={ classes }
+						onClick={ ( e ) => {
+							e.preventDefault();
+							setCurrentCategory( key );
+						} }
+					>
+						<span className="editor">{ categories[ key ] }</span>
+						<span className="count">{ count[ key ] }</span>
+					</a>
+				);
+			} ) }
+		</div>
+	);
+};
+
+export default compose(
+	withSelect( ( select ) => {
+		const { getCurrentCategory } = select( 'neve-onboarding' );
+		return {
+			category: getCurrentCategory(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { setCurrentCategory } = dispatch( 'neve-onboarding' );
+		return {
+			setCurrentCategory: ( category ) => setCurrentCategory( category ),
+		};
+	} )
+)( CategoriesTabs );

--- a/assets/src/Components/CategorySelector.js
+++ b/assets/src/Components/CategorySelector.js
@@ -1,0 +1,91 @@
+import classnames from 'classnames';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Button, Dashicon, Popover } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+const CategorySelector = ( {
+	categories,
+	count,
+	category,
+	setCurrentCategory,
+} ) => {
+	const [ open, setOpen ] = useState( false );
+	const toggleDropdown = () => setOpen( ! open );
+	const wrapClasses = classnames( [
+		'ob-dropdown',
+		'editor-selector',
+		{ small: true },
+	] );
+	return (
+		<div className={ wrapClasses }>
+			<Button onClick={ toggleDropdown } className="select ob-dropdown">
+				<span>{ categories[ category ] }</span>
+				<span className="count">{ count[ category ] }</span>
+				<Dashicon
+					size={ 14 }
+					icon={ open ? 'arrow-up-alt2' : 'arrow-down-alt2' }
+				/>
+				{ open && (
+					<Popover
+						position="bottom center"
+						onClose={ toggleDropdown }
+						noArrow
+					>
+						{ open && (
+							<ul className="options">
+								{ Object.keys( categories ).map(
+									( key, index ) => {
+										if ( key === category ) {
+											return null;
+										}
+										if ( 1 > count[ key ] ) {
+											return null;
+										}
+										return (
+											<li key={ index }>
+												<a
+													href="#"
+													onClick={ ( e ) => {
+														e.preventDefault();
+														setCurrentCategory(
+															key
+														);
+														setOpen( false );
+													} }
+												>
+													<span>
+														{ categories[ key ] }
+													</span>
+													<span className="count">
+														{ count[ key ] }
+													</span>
+												</a>
+											</li>
+										);
+									}
+								) }
+							</ul>
+						) }
+					</Popover>
+				) }
+			</Button>
+		</div>
+	);
+};
+
+export default compose(
+	withSelect( ( select ) => {
+		const { getCurrentCategory } = select( 'neve-onboarding' );
+		return {
+			category: getCurrentCategory(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { setCurrentCategory } = dispatch( 'neve-onboarding' );
+		return {
+			setCurrentCategory: ( category ) => setCurrentCategory( category ),
+		};
+	} )
+)( CategorySelector );

--- a/assets/src/Components/Search.js
+++ b/assets/src/Components/Search.js
@@ -1,16 +1,22 @@
+/* global tiobDash */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { Button, Dashicon, Popover } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import classnames from 'classnames';
+import { isTabbedEditor } from '../utils/common';
 
 const Search = ( {
 	count,
 	categories,
+	editors,
 	onSearch,
 	category,
+	editor,
+	onlyProSites,
 	setCurrentCategory,
+	setCurrentEditor,
 	query,
 	className,
 } ) => {
@@ -82,6 +88,123 @@ const Search = ( {
 			</div>
 		);
 	};
+	const EditorDropdown = () => {
+		return (
+			<div className="ob-dropdown categories-selector">
+				<Button
+					onClick={ toggleDropdown }
+					className="select ob-dropdown"
+				>
+					<span className="label-editor">
+						<span className="icon-wrap">
+							<img
+								className="editor-icon"
+								src={
+									tiobDash.assets +
+									'img/' +
+									editors[ editor ].icon
+								}
+								alt={ __(
+									'Builder Logo',
+									'templates-patterns-collection'
+								) }
+							/>
+						</span>
+						{ onlyProSites.includes( editor ) && (
+							<Dashicon
+								icon="lock"
+								style={ {
+									fontSize: '16px',
+									width: '16px',
+									height: '16px',
+									marginLeft: '0',
+								} }
+							/>
+						) }
+						{ editors[ editor ].niceName }
+					</span>
+					<Dashicon
+						size={ 14 }
+						icon={ open ? 'arrow-up-alt2' : 'arrow-down-alt2' }
+					/>
+					{ open && (
+						<Popover
+							position="bottom center"
+							onClose={ toggleDropdown }
+							noArrow
+						>
+							{ open && (
+								<ul className="options">
+									{ Object.keys( editors ).map(
+										( key, index ) => {
+											if ( key === editor ) {
+												return null;
+											}
+											return (
+												<li key={ index }>
+													<a
+														href="#"
+														onClick={ ( e ) => {
+															e.preventDefault();
+															setCurrentEditor(
+																key
+															);
+															setOpen( false );
+														} }
+													>
+														<span className="label-editor">
+															<span className="icon-wrap">
+																<img
+																	className="editor-icon"
+																	src={
+																		tiobDash.assets +
+																		'img/' +
+																		editors[
+																			key
+																		].icon
+																	}
+																	alt={ __(
+																		'Builder Logo',
+																		'templates-patterns-collection'
+																	) }
+																/>
+															</span>
+															{ onlyProSites.includes(
+																key
+															) && (
+																<Dashicon
+																	icon="lock"
+																	style={ {
+																		fontSize:
+																			'16px',
+																		width:
+																			'16px',
+																		height:
+																			'16px',
+																	} }
+																/>
+															) }
+															{
+																editors[ key ]
+																	.niceName
+															}
+														</span>
+														<span className="count">
+															{ count[ key ] }
+														</span>
+													</a>
+												</li>
+											);
+										}
+									) }
+								</ul>
+							) }
+						</Popover>
+					) }
+				</Button>
+			</div>
+		);
+	};
 
 	const wrapClasses = classnames( className, 'header-form' );
 
@@ -105,7 +228,8 @@ const Search = ( {
 						) + '...'
 					}
 				/>
-				<CategoriesDropdown />
+				{ isTabbedEditor && <CategoriesDropdown /> }
+				{ ! isTabbedEditor && <EditorDropdown /> }
 			</div>
 		</div>
 	);
@@ -113,20 +237,24 @@ const Search = ( {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getCurrentCategory, getSearchQuery } = select(
+		const { getCurrentCategory, getCurrentEditor, getSearchQuery } = select(
 			'neve-onboarding'
 		);
 		return {
+			editor: getCurrentEditor(),
 			category: getCurrentCategory(),
 			query: getSearchQuery(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { setCurrentCategory, setSearchQuery } = dispatch(
-			'neve-onboarding'
-		);
+		const {
+			setCurrentCategory,
+			setCurrentEditor,
+			setSearchQuery,
+		} = dispatch( 'neve-onboarding' );
 		return {
 			setCurrentCategory: ( category ) => setCurrentCategory( category ),
+			setCurrentEditor: ( editor ) => setCurrentEditor( editor ),
 			onSearch: ( query ) => setSearchQuery( query ),
 		};
 	} )

--- a/assets/src/Components/StarterSiteCard.js
+++ b/assets/src/Components/StarterSiteCard.js
@@ -16,7 +16,7 @@ const StarterSiteCard = ( {
 	setInstallModal,
 	setImportingPages,
 } ) => {
-	const { upsell, slug, screenshot, title, has_templates } = data;
+	const { upsell, screenshot, title, has_templates, isNew } = data;
 	const [ actionsClass, setActionClass ] = useState( '' );
 
 	const showActions = () => {
@@ -54,9 +54,16 @@ const StarterSiteCard = ( {
 			onMouseLeave={ hideActions }
 			className={ cardClassNames }
 		>
+			{ isNew && (
+				<span className="new-badge">
+					{ __(
+						'New',
+						'templates-patterns-collection'
+					).toUpperCase() }
+				</span>
+			) }
 			<div className="top">
 				<div className={ 'actions ' + actionsClass }>
-
 					<Button isSecondary onClick={ launchPreview }>
 						{ __( 'Preview', 'templates-patterns-collection' ) }
 					</Button>

--- a/assets/src/Components/StarterSites/Filters.js
+++ b/assets/src/Components/StarterSites/Filters.js
@@ -8,10 +8,12 @@ import Notification from '../Notification';
 
 import Logo from '../Icon';
 import Search from '../Search';
-import { CATEGORIES, EDITOR_MAP } from '../../utils/common';
+import { CATEGORIES, EDITOR_MAP, isTabbedEditor } from '../../utils/common';
 import EditorSelector from '../EditorSelector';
 import VizSensor from 'react-visibility-sensor';
 import EditorTabs from '../EditorTabs';
+import CategoriesTabs from '../CategoriesTabs';
+import CategorySelector from "../CategorySelector";
 
 const Filters = ( {
 	filterByCategory,
@@ -79,14 +81,28 @@ const Filters = ( {
 						) }
 						<Search
 							className="in-sticky"
-							count={ counted.categories }
+							count={
+								isTabbedEditor
+									? counted.categories
+									: counted.builders
+							}
 							categories={ CATEGORIES }
+							editors={ EDITOR_MAP }
+							onlyProSites={ onlyProBuilders }
 						/>
-						<EditorSelector
-							isSmall
-							count={ counted.builders }
-							EDITOR_MAP={ EDITOR_MAP }
-						/>
+						{ isTabbedEditor && (
+							<EditorSelector
+								isSmall
+								count={ counted.builders }
+								EDITOR_MAP={ EDITOR_MAP }
+							/>
+						) }
+						{ ! isTabbedEditor && (
+							<CategorySelector
+								count={ counted.categories }
+								categories={ CATEGORIES }
+							/>
+						) }
 					</div>
 				</div>
 			) }
@@ -111,15 +127,29 @@ const Filters = ( {
 					/>
 
 					<Search
-						count={ counted.categories }
+						count={
+							isTabbedEditor
+								? counted.categories
+								: counted.builders
+						}
 						categories={ CATEGORIES }
+						editors={ EDITOR_MAP }
+						onlyProSites={ onlyProBuilders }
 					/>
 
-					<EditorTabs
-						EDITOR_MAP={ EDITOR_MAP }
-						onlyProSites={ onlyProBuilders }
-						count={ counted.builders }
-					/>
+					{ isTabbedEditor && (
+						<EditorTabs
+							EDITOR_MAP={ EDITOR_MAP }
+							onlyProSites={ onlyProBuilders }
+							count={ counted.builders }
+						/>
+					) }
+					{ ! isTabbedEditor && (
+						<CategoriesTabs
+							categories={ CATEGORIES }
+							count={ counted.categories }
+						/>
+					) }
 					{ ! tiobDash.isValidLicense && (
 						<Notification
 							data={ tiobDash.upsellNotifications.upsell_1 }

--- a/assets/src/scss/_search.scss
+++ b/assets/src/scss/_search.scss
@@ -16,6 +16,25 @@
     left: 10px;
   }
 
+  .label-editor {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    .icon-wrap{
+      width: 30px;
+      margin-right: 10px;
+      img {
+        position: relative;
+        opacity: 1;
+        width: 100%;
+        top: auto;
+        left: auto;
+        transform: unset;
+        border-radius: 50%;
+      }
+    }
+  }
+
   .ob-dropdown {
     width: 100%;
     height: 52px;

--- a/assets/src/scss/_starter-site-card.scss
+++ b/assets/src/scss/_starter-site-card.scss
@@ -17,6 +17,21 @@
 		overflow: hidden;
 	}
 
+	.new-badge {
+		position: absolute;
+		display: block;
+		z-index: 25;
+		padding: 5px 7px;
+		left: -10px;
+		top: 8px;
+		border-radius: 2px;
+		background-color: #D5E5F6;
+		font-style: normal;
+		font-weight: 800;
+		font-size: 12px;
+		color: #585858;
+	}
+
 	.fav {
 		position: absolute;
 		z-index: 2000;

--- a/assets/src/utils/common.js
+++ b/assets/src/utils/common.js
@@ -23,6 +23,8 @@ const getTabHash = ( tabs ) => {
 const untrailingSlashIt = ( str ) => str.replace( /\/$/, '' );
 const trailingSlashIt = ( str ) => untrailingSlashIt( str ) + '/';
 
+const isTabbedEditor = false;
+
 const TAGS = [
 	__( 'Business', 'templates-patterns-collection' ),
 	__( 'Ecommerce', 'templates-patterns-collection' ),
@@ -49,6 +51,9 @@ const EDITOR_MAP = {
 		icon: 'elementor.jpg',
 		niceName: 'Elementor',
 	},
+};
+
+const EDITOR_MAP_ARCHIVED = {
 	'beaver builder': {
 		icon: 'beaver.jpg',
 		niceName: (
@@ -75,4 +80,4 @@ const EDITOR_MAP = {
 	},
 };
 
-export { addUrlHash, getTabHash, trailingSlashIt, untrailingSlashIt, CATEGORIES, EDITOR_MAP, TAGS };
+export { addUrlHash, getTabHash, trailingSlashIt, untrailingSlashIt, isTabbedEditor, CATEGORIES, EDITOR_MAP, EDITOR_MAP_ARCHIVED, TAGS };

--- a/e2e-tests/cypress/integration/dashboard.spec.ts
+++ b/e2e-tests/cypress/integration/dashboard.spec.ts
@@ -1,15 +1,15 @@
 describe('Dashboard Page - Default', function () {
-  const EDITORS = ['gutenberg', 'elementor', 'brizy', 'beaver', 'divi', 'thrive'];
-  const CATEGORIES = [
-    'All Categories',
-    'Free',
-    'Business',
-    'Portfolio',
-    'WooCommerce',
-    'Blog',
-    'Personal',
-    'Other',
-  ];
+  const EDITORS = ['gutenberg', 'elementor'];
+  const CATEGORIES = {
+    all: 'All Categories',
+    free: 'Free',
+    business: 'Business',
+    portfolio: 'Portfolio',
+    woocommerce: 'WooCommerce',
+    blog: 'Blog',
+    personal: 'Personal',
+    other: 'Other',
+  };
 
   before(function () {
     cy.visit('/');
@@ -68,46 +68,48 @@ describe('Dashboard Page - Default', function () {
     cy.get('.header-form:not(.in-sticky) .search input').clear();
   });
 
-  it('Editor Tabs Functionality', function () {
-    cy.get('.tab.gutenberg').should('have.class', 'active');
-    EDITORS.map((editor) => {
-      cy.get(`.tab.${editor}`).as('tab');
+  it('Categories Tabs Functionality', function () {
+    cy.get('.tab.all').should('have.class', 'active');
+    Object.keys(CATEGORIES).map((category) => {
+      cy.get(`.tab.${category}`).as('tab');
       cy.get('@tab').click();
       cy.get('@tab').should('have.class', 'active');
     });
-    cy.get('.tab.gutenberg').click().should('have.class', 'active');
+    cy.get('.tab.all').click().should('have.class', 'active');
   });
-  it('Categories Functionality', function () {
-    const ALL = 'All Categories';
+  it('Editor Functionality', function () {
+    const GTB = 'Gutenberg';
     cy.get('.categories-selector button').last().as('dropdown');
 
-    CATEGORIES.map((category) => {
-      if (category === ALL) {
+    EDITORS.map((editor) => {
+      const editorName = editor.charAt(0).toUpperCase() + editor.slice(1);
+      if (editorName === GTB) {
         return;
       }
       cy.get('@dropdown').click({ force: true });
-      cy.get('.categories-selector li').contains(category).click();
-      cy.get('.categories-selector button').should('contain', category);
+      cy.get('.categories-selector li').contains(editorName).click();
+      cy.get('.categories-selector button').should('contain', editorName);
     });
     cy.get('@dropdown').click({ force: true });
-    cy.get('.categories-selector li').contains(ALL).click();
-    cy.get('.categories-selector button').should('contain', ALL);
+    cy.get('.categories-selector li').contains(GTB).click();
+    cy.get('.categories-selector button').should('contain', GTB);
   });
 
   it('Sticky Nav Works', function () {
     cy.scrollTo('top');
     const CATEGORY = 'Blog';
+    const EDITOR = 'Elementor';
     cy.get('.sticky-nav').should('exist');
     cy.get('.header-form .search input').last().type(CATEGORY);
     cy.get('.categories-selector button').last().click({ force: true });
-    cy.get('.categories-selector li').contains(CATEGORY).click({ force: true });
+    cy.get('.categories-selector li').contains(EDITOR).click({ force: true });
 
     cy.scrollTo('bottom').wait(100).scrollTo('bottom').wait(100);
 
     cy.get('.sticky-nav').should('exist').and('be.visible');
 
     cy.get('.sticky-nav input').should('have.value', CATEGORY);
-    cy.get('.sticky-nav .categories-selector button').should('contain', CATEGORY);
+    cy.get('.sticky-nav .categories-selector button').should('contain', EDITOR);
   });
 });
 

--- a/includes/Sites_Listing.php
+++ b/includes/Sites_Listing.php
@@ -108,6 +108,7 @@ class Sites_Listing {
 	 */
 	private function get_sites() {
 		$cache = get_transient( $this->transient_key );
+
 		if ( $cache !== false ) {
 			$response = $cache;
 		} else {

--- a/includes/Sites_Listing.php
+++ b/includes/Sites_Listing.php
@@ -108,11 +108,9 @@ class Sites_Listing {
 	 */
 	private function get_sites() {
 		$cache = get_transient( $this->transient_key );
-		$cache = false;
 		if ( $cache !== false ) {
 			$response = $cache;
 		} else {
-			add_filter('https_ssl_verify', '__return_false');
 			$response = wp_remote_get( esc_url( self::get_api_path() ) );
 
 			if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {

--- a/includes/Sites_Listing.php
+++ b/includes/Sites_Listing.php
@@ -108,10 +108,11 @@ class Sites_Listing {
 	 */
 	private function get_sites() {
 		$cache = get_transient( $this->transient_key );
-
+		$cache = false;
 		if ( $cache !== false ) {
 			$response = $cache;
 		} else {
+			add_filter('https_ssl_verify', '__return_false');
 			$response = wp_remote_get( esc_url( self::get_api_path() ) );
 
 			if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {


### PR DESCRIPTION
### Summary
Removed Beaver Builder, Brizy, Divi & Thrive and moved them as archived.
Changed the Categories as Tabs and the Editors as dropdown same as on demosites.io
Added a new label for sites marked as `NEW`

### Screenshots
![image](https://user-images.githubusercontent.com/23024731/175551686-f07e9c72-67ba-4b02-998b-51bd6cfdb086.png)

![image](https://user-images.githubusercontent.com/23024731/175551846-39841d0d-394e-496e-ad56-35dbf75cda43.png)



### Test instructions
1. Test with the data from staging after https://github.com/Codeinwp/demo-data-exporter/pull/110 is merged into development
2. Check that filtering works as before
3. Check that the New label is present
4. Check that imports and all other features work as before.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/demo-data-exporter#91.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
