### PR TITLE
Have TPC Neve independent

### DIFF
--- a/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js
+++ b/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js
@@ -63,6 +63,8 @@ const DemoSiteTemplatesImport = ( {
 	};
 
 	const handleSingleImport = ( item ) => {
+		console.log( item );
+		console.log( 'Handle Import Single' );
 		if ( themeStatus ) {
 			setInstallModal( true );
 
@@ -75,6 +77,7 @@ const DemoSiteTemplatesImport = ( {
 
 	const launchImport = ( e ) => {
 		e.preventDefault();
+		console.log( 'Launch Import' );
 
 		if ( themeStatus ) {
 			setInstallModal( true );

--- a/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js
+++ b/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js
@@ -15,8 +15,6 @@ const DemoSiteTemplatesImport = ( {
 	slug,
 	cancel,
 	setModal,
-	setInstallModal,
-	themeStatus,
 	site,
 	editor,
 	setTemplateModal,
@@ -67,12 +65,6 @@ const DemoSiteTemplatesImport = ( {
 
 	const launchImport = ( e ) => {
 		e.preventDefault();
-
-		if ( themeStatus ) {
-			setInstallModal( true );
-
-			return false;
-		}
 		setModal( true );
 	};
 
@@ -268,7 +260,6 @@ export default compose(
 		const {
 			setSingleTemplateImport,
 			setImportModalStatus,
-			setInstallModalStatus,
 			setTemplateModal,
 		} = dispatch( 'neve-onboarding' );
 
@@ -279,21 +270,16 @@ export default compose(
 		return {
 			cancel,
 			setModal: ( status ) => setImportModalStatus( status ),
-			setInstallModal: ( status ) => setInstallModalStatus( status ),
 			setTemplateModal,
 		};
 	} ),
 	withSelect( ( select ) => {
-		const {
-			getTemplateModal,
-			getThemeAction,
-			getCurrentSite,
-			getCurrentEditor,
-		} = select( 'neve-onboarding' );
+		const { getTemplateModal, getCurrentSite, getCurrentEditor } = select(
+			'neve-onboarding'
+		);
 
 		return {
 			templateModal: getTemplateModal(),
-			themeStatus: getThemeAction().action || false,
 			site: getCurrentSite(),
 			editor: getCurrentEditor(),
 		};

--- a/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js
+++ b/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js
@@ -52,12 +52,13 @@ const DemoSiteTemplatesImport = ( {
 
 	const handleBulk = ( e ) => {
 		e.preventDefault();
+		console.log( 'Handle Import Bulk' );
 
-		if ( themeStatus ) {
-			setInstallModal( true );
-
-			return false;
-		}
+		// if ( themeStatus ) {
+		// 	setInstallModal( true );
+		//
+		// 	return false;
+		// }
 		setToImport( templates );
 		setTemplateModal( true );
 	};
@@ -65,11 +66,11 @@ const DemoSiteTemplatesImport = ( {
 	const handleSingleImport = ( item ) => {
 		console.log( item );
 		console.log( 'Handle Import Single' );
-		if ( themeStatus ) {
-			setInstallModal( true );
-
-			return false;
-		}
+		// if ( themeStatus ) {
+		// 	setInstallModal( true );
+		//
+		// 	return false;
+		// }
 		setToImport( [ item ] );
 
 		setTemplateModal( true );

--- a/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js
+++ b/assets/src/Components/CloudLibrary/DemoSiteTemplatesImport.js
@@ -50,35 +50,23 @@ const DemoSiteTemplatesImport = ( {
 		setPreviewUrl( url );
 	};
 
-	const handleBulk = ( e ) => {
-		e.preventDefault();
-		console.log( 'Handle Import Bulk' );
-
-		// if ( themeStatus ) {
-		// 	setInstallModal( true );
-		//
-		// 	return false;
-		// }
-		setToImport( templates );
+	const doImport = ( templatesToImport ) => {
+		setToImport( templatesToImport );
 		setTemplateModal( true );
 	};
 
-	const handleSingleImport = ( item ) => {
-		console.log( item );
-		console.log( 'Handle Import Single' );
-		// if ( themeStatus ) {
-		// 	setInstallModal( true );
-		//
-		// 	return false;
-		// }
-		setToImport( [ item ] );
+	const handleBulk = ( e ) => {
+		e.preventDefault();
 
-		setTemplateModal( true );
+		doImport( templates );
+	};
+
+	const handleSingleImport = ( item ) => {
+		doImport( [ item ] );
 	};
 
 	const launchImport = ( e ) => {
 		e.preventDefault();
-		console.log( 'Launch Import' );
 
 		if ( themeStatus ) {
 			setInstallModal( true );

--- a/assets/src/Components/CloudLibrary/ImportTemplatesModal.js
+++ b/assets/src/Components/CloudLibrary/ImportTemplatesModal.js
@@ -18,9 +18,7 @@ const ImportTemplatesModal = ( {
 	templatesData,
 	cancel,
 	siteData,
-	themeStatus,
 	themeData,
-	setInstallModal,
 	setModal,
 	isUserTemplate = false,
 	generalTemplates = false,
@@ -105,14 +103,6 @@ const ImportTemplatesModal = ( {
 
 	const launchImport = ( e ) => {
 		e.preventDefault();
-
-		console.log( 'Launch Import' );
-		if ( themeStatus ) {
-			setInstallModal( true );
-
-			return false;
-		}
-
 		setModal( true );
 	};
 
@@ -374,7 +364,6 @@ export default compose(
 	withSelect( ( select ) => {
 		const { getThemeAction, getCurrentSite } = select( 'neve-onboarding' );
 		return {
-			themeStatus: getThemeAction().action || false,
 			siteData: getCurrentSite(),
 			themeData: getThemeAction() || false,
 		};
@@ -383,7 +372,6 @@ export default compose(
 		const {
 			setTemplateModal,
 			setImportModalStatus,
-			setInstallModalStatus,
 		} = dispatch( 'neve-onboarding' );
 
 		return {
@@ -391,7 +379,6 @@ export default compose(
 				setTemplateModal( null );
 			},
 			setModal: ( status ) => setImportModalStatus( status ),
-			setInstallModal: ( status ) => setInstallModalStatus( status ),
 		};
 	} )
 )( ImportTemplatesModal );

--- a/assets/src/Components/CloudLibrary/ImportTemplatesModal.js
+++ b/assets/src/Components/CloudLibrary/ImportTemplatesModal.js
@@ -117,14 +117,11 @@ const ImportTemplatesModal = ( {
 	};
 
 	const runTemplatesImport = () => {
-		console.log( 'runTemplatesImport' );
 		setImporting( true );
 		const data = templatesData.map( ( item, index ) => {
 			return { ...item, ...templates[ index ] };
 		} );
-		// console.log( data );
-		// console.log( templatesData );
-		// return false;
+
 		const callbackImportTemplate = () => {
 			try {
 				importTemplates( data ).then( ( r ) => {
@@ -132,8 +129,6 @@ const ImportTemplatesModal = ( {
 						console.log( r.message );
 						return false;
 					}
-					console.log( 'import done' );
-					console.log( data );
 
 					setImported( r.pages );
 					setImporting( 'done' );

--- a/assets/src/Components/CloudLibrary/Library.js
+++ b/assets/src/Components/CloudLibrary/Library.js
@@ -6,7 +6,7 @@ import { useEffect, useState, Fragment } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Spinner, Button, Icon } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
 
 import { fetchLibrary } from './common';
 import ListItem from './ListItem';
@@ -214,7 +214,7 @@ const Library = ( {
 		library[ type ].find( ( item ) => previewUrl === item.link );
 	const wrapClasses = classnames( 'cloud-items', {
 		'is-grid': isGrid || ( ! userStatus && ! isGeneral ),
-		'is-dummy': ! userStatus && ! isGeneral,
+		'is-dummy': ( ! userStatus && ! isGeneral ) || themeData !== false,
 	} );
 
 	const handlePrevious = () => {
@@ -281,7 +281,11 @@ const Library = ( {
 		} );
 	};
 
-	const UpsellModal = ( { title, description } ) => {
+	const themeURL = 'https://wordpress.org/themes/neve/';
+	const upgradeURL =
+		'https://themeisle.com/themes/neve/upgrade/?utm_medium=nevedashboard&utm_source=neve&utm_campaign=templatecloud&utm_content=upgradetoprobtn and https://themeisle.com/themes/neve/neve-upgrade-new/?utm_medium=nevedashboard&utm_source=neve&utm_campaign=templatecloud&utm_content=changeplanbtn';
+
+	const UpsellModal = ( { title, description, showUpgradeBtn = true } ) => {
 		return (
 			<div className={ wrapClasses }>
 				<div className="table">
@@ -303,17 +307,23 @@ const Library = ( {
 							<div className="info">
 								<h3>{ title }</h3>
 
-								<p>{ description }</p>
+								<p
+									dangerouslySetInnerHTML={ {
+										__html: description,
+									} }
+								></p>
 
-								<Button
-									variant="primary"
-									isPrimary
-									href="https://themeisle.com/themes/neve/upgrade/?utm_medium=nevedashboard&utm_source=neve&utm_campaign=templatecloud&utm_content=upgradetoprobtn and
+								{ showUpgradeBtn && (
+									<Button
+										variant="primary"
+										isPrimary
+										href="https://themeisle.com/themes/neve/upgrade/?utm_medium=nevedashboard&utm_source=neve&utm_campaign=templatecloud&utm_content=upgradetoprobtn and
 									https://themeisle.com/themes/neve/neve-upgrade-new/?utm_medium=nevedashboard&utm_source=neve&utm_campaign=templatecloud&utm_content=changeplanbtn"
-									target="_blank"
-								>
-									{ __( 'Upgrade to PRO' ) }
-								</Button>
+										target="_blank"
+									>
+										{ __( 'Upgrade to PRO' ) }
+									</Button>
+								) }
 							</div>
 							<div className="icon">
 								<Icon icon={ Logo } />
@@ -328,14 +338,23 @@ const Library = ( {
 	if ( themeData !== false ) {
 		return (
 			<UpsellModal
-				title={
-					isGeneral
-						? __( 'Coming soon' )
-						: __( 'Templates Cloud is a PRO Feature' )
-				}
-				description={ __(
-					'Right now this feature is not available with your current setup. if you want to use it, you need to install Neve + Neve Pro'
+				title={ __( 'Coming soon' ) }
+				description={ sprintf(
+					// translators: %1$s: Theme Name %2$s Plugin Name.
+					__(
+						'Right now this feature is not available with your current setup. if you want to use it, you need to install %1$s theme and %2$s plugin',
+						'template-patterns-collection'
+					),
+					`<a href="${ themeURL }" target="_blank" rel="noreferrer">${ __(
+						'Neve',
+						'template-patterns-collection'
+					) }</a>`,
+					`<a href="${ upgradeURL }" target="_blank" rel="noreferrer">${ __(
+						'Neve Pro Addon',
+						'template-patterns-collection'
+					) }</a>`
 				) }
+				showUpgradeBtn={ false }
 			/>
 		);
 	}

--- a/assets/src/Components/CloudLibrary/Library.js
+++ b/assets/src/Components/CloudLibrary/Library.js
@@ -345,14 +345,8 @@ const Library = ( {
 						'Right now this feature is not available with your current setup. if you want to use it, you need to install %1$s theme and %2$s plugin',
 						'template-patterns-collection'
 					),
-					`<a href="${ themeURL }" target="_blank" rel="noreferrer">${ __(
-						'Neve',
-						'template-patterns-collection'
-					) }</a>`,
-					`<a href="${ upgradeURL }" target="_blank" rel="noreferrer">${ __(
-						'Neve Pro Addon',
-						'template-patterns-collection'
-					) }</a>`
+					`<a href="${ themeURL }" target="_blank" rel="noreferrer">Neve</a>`,
+					`<a href="${ upgradeURL }" target="_blank" rel="noreferrer">Neve Pro Addon</a>`
 				) }
 				showUpgradeBtn={ false }
 			/>

--- a/assets/src/Components/CloudLibrary/Library.js
+++ b/assets/src/Components/CloudLibrary/Library.js
@@ -203,12 +203,6 @@ const Library = ( {
 	};
 
 	const handleImport = ( id ) => {
-		console.log( 'Page template import' );
-		// if ( themeStatus ) {
-		// 	setInstallModal( true );
-		//
-		// 	return false;
-		// }
 		setToImport( [ id ] );
 		setTemplateModal( true );
 	};

--- a/assets/src/Components/CloudLibrary/Library.js
+++ b/assets/src/Components/CloudLibrary/Library.js
@@ -19,12 +19,11 @@ import Logo from '../Icon';
 const Library = ( {
 	isGeneral,
 	setPreview,
-	setInstallModal,
 	setTemplateModal,
 	templateModal,
-	themeStatus,
 	currentTab,
 	userStatus,
+	themeData,
 } ) => {
 	const [ library, setLibrary ] = useState( {
 		gutenberg: [],
@@ -282,7 +281,7 @@ const Library = ( {
 		} );
 	};
 
-	if ( ! userStatus && ! isGeneral ) {
+	const UpsellModal = ( { title, description } ) => {
 		return (
 			<div className={ wrapClasses }>
 				<div className="table">
@@ -302,15 +301,9 @@ const Library = ( {
 					<div className="upsell-modal">
 						<div className="upsell-modal-content">
 							<div className="info">
-								<h3>
-									{ __( 'Templates Cloud is a PRO Feature' ) }
-								</h3>
+								<h3>{ title }</h3>
 
-								<p>
-									{ __(
-										'Unlock the Templates Cloud features and save your pages or posts in the cloud.'
-									) }
-								</p>
+								<p>{ description }</p>
 
 								<Button
 									variant="primary"
@@ -329,6 +322,32 @@ const Library = ( {
 					</div>
 				</div>
 			</div>
+		);
+	};
+
+	if ( themeData !== false ) {
+		return (
+			<UpsellModal
+				title={
+					isGeneral
+						? __( 'Coming soon' )
+						: __( 'Templates Cloud is a PRO Feature' )
+				}
+				description={ __(
+					'Right now this feature is not available with your current setup. if you want to use it, you need to install Neve + Neve Pro'
+				) }
+			/>
+		);
+	}
+
+	if ( ! userStatus && ! isGeneral ) {
+		return (
+			<UpsellModal
+				title={ __( 'Templates Cloud is a PRO Feature' ) }
+				description={ __(
+					'Unlock the Templates Cloud features and save your pages or posts in the cloud.'
+				) }
+			/>
 		);
 	}
 
@@ -532,7 +551,7 @@ export default compose(
 
 		return {
 			templateModal: getTemplateModal(),
-			themeStatus: getThemeAction().action || false,
+			themeData: getThemeAction() || false,
 			editor: getCurrentEditor(),
 			currentTab: getCurrentTab(),
 			userStatus: getUserStatus(),

--- a/assets/src/Components/CloudLibrary/Library.js
+++ b/assets/src/Components/CloudLibrary/Library.js
@@ -203,11 +203,12 @@ const Library = ( {
 	};
 
 	const handleImport = ( id ) => {
-		if ( themeStatus ) {
-			setInstallModal( true );
-
-			return false;
-		}
+		console.log( 'Page template import' );
+		// if ( themeStatus ) {
+		// 	setInstallModal( true );
+		//
+		// 	return false;
+		// }
 		setToImport( [ id ] );
 		setTemplateModal( true );
 	};

--- a/assets/src/Components/Header.js
+++ b/assets/src/Components/Header.js
@@ -11,12 +11,7 @@ import classnames from 'classnames';
 import { v4 as uuidv4 } from 'uuid';
 import { addUrlHash, getTabHash } from '../utils/common';
 
-const TabNavigation = ( {
-	setCurrentTab,
-	currentTab,
-	isFetching,
-	themeData,
-} ) => {
+const TabNavigation = ( { setCurrentTab, currentTab, isFetching } ) => {
 	const buttons = {
 		starterSites: __( 'Starter Sites', 'templates-patterns-collection' ),
 		pageTemplates: __( 'Page Templates', 'templates-patterns-collection' ),
@@ -76,10 +71,6 @@ const TabNavigation = ( {
 	return (
 		<div className="header-nav">
 			{ Object.keys( buttons ).map( ( slug ) => {
-				// We hide the Page Templates if Neve is not present
-				if ( slug === 'pageTemplates' && themeData !== false ) {
-					return '';
-				}
 				return (
 					<Button
 						href={ '#' + slug }
@@ -167,17 +158,13 @@ export default compose(
 		};
 	} ),
 	withSelect( ( select ) => {
-		const {
-			getOnboardingStatus,
-			getCurrentTab,
-			getFetching,
-			getThemeAction,
-		} = select( 'neve-onboarding' );
+		const { getOnboardingStatus, getCurrentTab, getFetching } = select(
+			'neve-onboarding'
+		);
 		return {
 			isOnboarding: getOnboardingStatus(),
 			currentTab: getCurrentTab(),
 			isFetching: getFetching(),
-			themeData: getThemeAction() || false,
 		};
 	} )
 )( Header );

--- a/assets/src/Components/Header.js
+++ b/assets/src/Components/Header.js
@@ -1,8 +1,7 @@
 /* global tiobDash, localStorage */
 import { withSelect, withDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { Button, Icon } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { update } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -12,7 +11,12 @@ import classnames from 'classnames';
 import { v4 as uuidv4 } from 'uuid';
 import { addUrlHash, getTabHash } from '../utils/common';
 
-const TabNavigation = ( { setCurrentTab, currentTab, isFetching } ) => {
+const TabNavigation = ( {
+	setCurrentTab,
+	currentTab,
+	isFetching,
+	themeData,
+} ) => {
 	const buttons = {
 		starterSites: __( 'Starter Sites', 'templates-patterns-collection' ),
 		pageTemplates: __( 'Page Templates', 'templates-patterns-collection' ),
@@ -33,51 +37,59 @@ const TabNavigation = ( { setCurrentTab, currentTab, isFetching } ) => {
 	};
 
 	const onHashChanged = () => {
-		const hash = getTabHash(buttons);
-		if (null === hash) {
+		const hash = getTabHash( buttons );
+		if ( null === hash ) {
 			return;
 		}
 
-		const menu = document.getElementById('menu-appearance');
-		const libraryLink = menu.querySelector('a[href="themes.php?page=tiob-starter-sites#library"]');
-		const starterLink = menu.querySelector('a[href="themes.php?page=tiob-starter-sites"]');
+		const menu = document.getElementById( 'menu-appearance' );
+		const libraryLink = menu.querySelector(
+			'a[href="themes.php?page=tiob-starter-sites#library"]'
+		);
+		const starterLink = menu.querySelector(
+			'a[href="themes.php?page=tiob-starter-sites"]'
+		);
 
 		// This is used only to set the active state of the links from the left admin nav.
 		// So we check that those items exist before trying to mutate them.
 		if ( libraryLink && starterLink ) {
 			const libraryItem = libraryLink.parentElement;
 			const starterSitesItem = starterLink.parentElement;
-			const activeItem = menu.querySelector('.current');
+			const activeItem = menu.querySelector( '.current' );
 
-			activeItem.classList.remove('current');
-			libraryItem.classList.remove('current');
-			if ( hash === 'library' ){
-				libraryItem.classList.add('current');
+			activeItem.classList.remove( 'current' );
+			libraryItem.classList.remove( 'current' );
+			if ( hash === 'library' ) {
+				libraryItem.classList.add( 'current' );
 			} else {
-				starterSitesItem.classList.add('current');
+				starterSitesItem.classList.add( 'current' );
 			}
 		}
-		setCurrentTab(hash);
-	}
+		setCurrentTab( hash );
+	};
 
-	useEffect(() => {
+	useEffect( () => {
 		onHashChanged();
-		window.addEventListener('hashchange', onHashChanged)
-	}, []);
+		window.addEventListener( 'hashchange', onHashChanged );
+	}, [] );
 
 	return (
 		<div className="header-nav">
 			{ Object.keys( buttons ).map( ( slug ) => {
+				// We hide the Page Templates if Neve is not present
+				if ( slug === 'pageTemplates' && themeData !== false ) {
+					return '';
+				}
 				return (
 					<Button
-						href={'#' + slug}
+						href={ '#' + slug }
 						key={ slug }
 						isTertiary
 						isPressed={ slug === currentTab }
-						onClick={ (e) => {
+						onClick={ ( e ) => {
 							e.preventDefault();
 							setCurrentTab( slug );
-							addUrlHash(slug);
+							addUrlHash( slug );
 						} }
 					>
 						{ buttons[ slug ] }
@@ -155,13 +167,17 @@ export default compose(
 		};
 	} ),
 	withSelect( ( select ) => {
-		const { getOnboardingStatus, getCurrentTab, getFetching } = select(
-			'neve-onboarding'
-		);
+		const {
+			getOnboardingStatus,
+			getCurrentTab,
+			getFetching,
+			getThemeAction,
+		} = select( 'neve-onboarding' );
 		return {
 			isOnboarding: getOnboardingStatus(),
 			currentTab: getCurrentTab(),
 			isFetching: getFetching(),
+			themeData: getThemeAction() || false,
 		};
 	} )
 )( Header );

--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -68,12 +68,7 @@ const ImportModal = ( {
 		cleanupAllowed
 	);
 
-	console.log( themeData );
-	console.log( importing );
-	console.log( fetching );
-
 	useEffect( () => {
-		console.log( 'Use effect call' );
 		const fetchAddress = siteData.remote_url || siteData.url;
 		// Use the line below if testing in a staging env:
 		// const fetchAddress = siteData.url || siteData.remote_url;
@@ -581,8 +576,6 @@ const ImportModal = ( {
 	}
 
 	const closeModal = () => {
-		console.log( 'Close request' );
-		console.log( importing );
 		if ( importing ) {
 			return false;
 		}

--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -62,8 +62,9 @@ const ImportModal = ( {
 	const [ fetching, setFetching ] = useState( true );
 	const [ pluginsOpened, setPluginsOpened ] = useState( true );
 	const [ optionsOpened, setOptionsOpened ] = useState( true );
+	const [ themeOpened, setThemeOpened ] = useState( true );
 
-	const { license, cleanupAllowed, themesURL } = tiobDash;
+	const { license, cleanupAllowed } = tiobDash;
 	const [ isCleanupAllowed, setIsCleanupAllowed ] = useState(
 		cleanupAllowed
 	);
@@ -155,6 +156,39 @@ const ImportModal = ( {
 			</p>
 		</div>
 	);
+	const Theme = () => {
+		const toggleOpen = () => {
+			setThemeOpened( ! themeOpened );
+		};
+		const rowClass = classnames( 'option-row', 'active' );
+		const { icon, title, tooltip } = {
+			icon: 'admin-appearance',
+			title: __( 'Neve', 'templates-patterns-collection' ),
+			tooltip: __(
+				'In order to import the starter site, Neve theme has to be installed and activated.',
+				'templates-patterns-collection'
+			),
+		};
+
+		return (
+			<PanelBody
+				onToggle={ toggleOpen }
+				opened={ themeOpened }
+				className="options general"
+				title={ __(
+					'Install required theme',
+					'templates-patterns-collection'
+				) }
+			>
+				<PanelRow className={ rowClass }>
+					<Icon icon={ icon } />
+					<span>{ title }</span>
+					{ tooltip && <CustomTooltip>{ tooltip }</CustomTooltip> }
+				</PanelRow>
+			</PanelBody>
+		);
+	};
+
 	const Options = () => {
 		let map = {
 			content: {
@@ -178,20 +212,6 @@ const ImportModal = ( {
 				),
 			},
 		};
-
-		if ( themeData !== false ) {
-			map = {
-				theme_install: {
-					icon: 'admin-appearance',
-					title: __( 'Neve', 'templates-patterns-collection' ),
-					tooltip: __(
-						'In order to import the starter site, Neve theme has to be installed and activated.',
-						'templates-patterns-collection'
-					),
-				},
-				...map,
-			};
-		}
 
 		if ( isCleanupAllowed === 'yes' ) {
 			map = {
@@ -615,6 +635,7 @@ const ImportModal = ( {
 								<ModalHead />
 								<Note />
 								<Panel className="modal-toggles">
+									{ themeData !== false && <Theme /> }
 									<Options />
 									<Plugins />
 								</Panel>

--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -235,9 +235,6 @@ const ImportModal = ( {
 					} );
 					const { icon, title, tooltip } = map[ id ];
 
-					console.log( id );
-					console.log( index );
-
 					return (
 						<PanelRow className={ rowClass } key={ index }>
 							<Icon icon={ icon } />

--- a/assets/src/Components/ImportStepper.js
+++ b/assets/src/Components/ImportStepper.js
@@ -5,9 +5,20 @@ import { Dashicon } from '@wordpress/components';
 const ImportStepper = ( { currentStep, progress, willDo } ) => {
 	const stepsMap = {
 		cleanup: {
-			label: __( 'Cleanup previous Import', 'templates-patterns-collection' ),
+			label: __(
+				'Cleanup previous Import',
+				'templates-patterns-collection'
+			),
 			status: progress.cleanup,
 			willDo: willDo.cleanup,
+		},
+		theme_install: {
+			label: __(
+				'Install and Activate Theme',
+				'templates-patterns-collection'
+			),
+			status: progress.theme_install,
+			willDo: willDo.theme_install,
 		},
 		plugins: {
 			label: __( 'Installing Plugins', 'templates-patterns-collection' ),

--- a/assets/src/Components/ImportStepper.js
+++ b/assets/src/Components/ImportStepper.js
@@ -14,7 +14,7 @@ const ImportStepper = ( { currentStep, progress, willDo } ) => {
 		},
 		theme_install: {
 			label: __(
-				'Install and Activate Theme',
+				'Installing and Activating the Theme',
 				'templates-patterns-collection'
 			),
 			status: progress.theme_install,

--- a/assets/src/Components/Main.js
+++ b/assets/src/Components/Main.js
@@ -44,8 +44,6 @@ const Onboarding = ( {
 					</div>
 				</div>
 			</div>
-			{/*{ installModal && <InstallModal /> }*/}
-			{/*{ importModal && currentSiteData && <ImportModal /> }*/}
 			{ importModal && currentSiteData && <ImportModal /> }
 		</Fragment>
 	);

--- a/assets/src/Components/Main.js
+++ b/assets/src/Components/Main.js
@@ -44,7 +44,8 @@ const Onboarding = ( {
 					</div>
 				</div>
 			</div>
-			{ installModal && <InstallModal /> }
+			{/*{ installModal && <InstallModal /> }*/}
+			{/*{ importModal && currentSiteData && <ImportModal /> }*/}
 			{ importModal && currentSiteData && <ImportModal /> }
 		</Fragment>
 	);

--- a/assets/src/Components/PreviewFrame.js
+++ b/assets/src/Components/PreviewFrame.js
@@ -12,16 +12,9 @@ const PreviewFrame = ( {
 	setSite,
 	setPreview,
 	setModal,
-	themeStatus,
-	setInstallModal,
 } ) => {
 	const handleImport = ( e ) => {
 		e.preventDefault();
-		if ( themeStatus ) {
-			setInstallModal( true );
-
-			return false;
-		}
 		setModal( true );
 	};
 	const handleNext = ( e ) => {
@@ -110,10 +103,9 @@ const PreviewFrame = ( {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getCurrentSite, getThemeAction } = select( 'neve-onboarding' );
+		const { getCurrentSite } = select( 'neve-onboarding' );
 		return {
 			siteData: getCurrentSite(),
-			themeStatus: getThemeAction().action || false,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
@@ -121,13 +113,11 @@ export default compose(
 			setCurrentSite,
 			setPreviewStatus,
 			setImportModalStatus,
-			setInstallModalStatus,
 		} = dispatch( 'neve-onboarding' );
 		return {
 			setSite: ( data ) => setCurrentSite( data ),
 			setPreview: ( status ) => setPreviewStatus( status ),
 			setModal: ( status ) => setImportModalStatus( status ),
-			setInstallModal: ( status ) => setInstallModalStatus( status ),
 		};
 	} )
 )( PreviewFrame );

--- a/assets/src/Components/StarterSiteCard.js
+++ b/assets/src/Components/StarterSiteCard.js
@@ -28,13 +28,14 @@ const StarterSiteCard = ( {
 
 	const launchImport = ( e ) => {
 		e.preventDefault();
+		console.log( 'Launch Import StarterSiteCard.js' );
 		setSite();
 
-		if ( themeStatus ) {
-			setInstallModal( true );
-
-			return false;
-		}
+		// if ( themeStatus ) {
+		// 	setInstallModal( true );
+		//
+		// 	return false;
+		// }
 		setModal( true );
 	};
 

--- a/assets/src/Components/StarterSiteCard.js
+++ b/assets/src/Components/StarterSiteCard.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { withDispatch, withSelect } from '@wordpress/data';
+import { withDispatch } from '@wordpress/data';
 import { Button, Dashicon } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -12,8 +12,6 @@ const StarterSiteCard = ( {
 	setSite,
 	setPreview,
 	setModal,
-	themeStatus,
-	setInstallModal,
 	setImportingPages,
 } ) => {
 	const { upsell, screenshot, title, has_templates, isNew } = data;
@@ -126,27 +124,18 @@ const StarterSiteCard = ( {
 };
 
 export default compose(
-	withSelect( ( select ) => {
-		const { getThemeAction } = select( 'neve-onboarding' );
-
-		return {
-			themeStatus: getThemeAction().action || false,
-		};
-	} ),
 	withDispatch( ( dispatch, { data } ) => {
 		const { slug } = data;
 		const {
 			setCurrentSite,
 			setPreviewStatus,
 			setImportModalStatus,
-			setInstallModalStatus,
 			setSingleTemplateImport,
 		} = dispatch( 'neve-onboarding' );
 		return {
 			setSite: () => setCurrentSite( data ),
 			setPreview: ( status ) => setPreviewStatus( status ),
 			setModal: ( status ) => setImportModalStatus( status ),
-			setInstallModal: ( status ) => setInstallModalStatus( status ),
 			setImportingPages: () => setSingleTemplateImport( slug ),
 		};
 	} )

--- a/assets/src/Components/StarterSiteCard.js
+++ b/assets/src/Components/StarterSiteCard.js
@@ -28,14 +28,8 @@ const StarterSiteCard = ( {
 
 	const launchImport = ( e ) => {
 		e.preventDefault();
-		console.log( 'Launch Import StarterSiteCard.js' );
-		setSite();
 
-		// if ( themeStatus ) {
-		// 	setInstallModal( true );
-		//
-		// 	return false;
-		// }
+		setSite();
 		setModal( true );
 	};
 

--- a/assets/src/scss/_custom-tooltip.scss
+++ b/assets/src/scss/_custom-tooltip.scss
@@ -11,6 +11,7 @@
 			+ .tiob-tooltip-content {
 				opacity: 1;
 				pointer-events: all;
+				z-index: 1;
 			}
 		}
 	}

--- a/assets/src/utils/site-import.js
+++ b/assets/src/utils/site-import.js
@@ -1,6 +1,6 @@
 /* global tiobDash */
 const { onboarding } = tiobDash;
-import { send } from './rest';
+import {get, send} from './rest';
 
 export const importWidgets = ( data ) => {
 	return send( onboarding.root + '/import_widgets', data );
@@ -12,7 +12,7 @@ export const importMods = ( data ) => {
 
 export const cleanupImport = ( data ) => {
 	return send( onboarding.root + '/cleanup', data );
-}
+};
 
 export const installPlugins = ( pluginArray ) => {
 	return send( onboarding.root + '/install_plugins', pluginArray );
@@ -23,13 +23,13 @@ export const importContent = ( data ) => {
 };
 
 export const importTemplates = async ( data ) => {
-	let plugins = {};
+	const plugins = {};
 
-	data.forEach( template => {
+	data.forEach( ( template ) => {
 		if ( 'elementor' === template.template_type ) {
 			plugins.elementor = true;
 		} else if ( 'beaver' === template.template_type ) {
-			plugins['beaver-builder-lite-version'] = true;
+			plugins[ 'beaver-builder-lite-version' ] = true;
 		}
 	} );
 
@@ -37,9 +37,33 @@ export const importTemplates = async ( data ) => {
 		try {
 			await installPlugins( plugins );
 		} catch ( e ) {
-			return error;
+			return e;
 		}
 	}
 
 	return send( onboarding.root + '/import_single_templates', data );
+};
+
+export const installTheme = (
+	slug = 'neve',
+	callbackSuccess,
+	callbackError
+) => {
+	wp.updates.installTheme( {
+		slug,
+		success: callbackSuccess,
+		error: callbackError,
+	} );
+};
+
+export const activateTheme = ( themeData, callbackSuccess, callbackError ) => {
+	const { themesURL } = tiobDash;
+	const url = `${ themesURL }?action=activate&stylesheet=${ themeData.slug }&_wpnonce=${ themeData.nonce }`;
+	get( url, true ).then( ( response ) => {
+		if ( response.status !== 200 ) {
+			callbackError( response );
+			return false;
+		}
+		callbackSuccess();
+	} );
 };

--- a/editor/src/components/list-item.js
+++ b/editor/src/components/list-item.js
@@ -35,6 +35,7 @@ const ListItem = ( {
 	const [ itemName, setItemName ] = useState( item.template_name );
 
 	const importItem = async () => {
+		console.log( 'Here' );
 		setLoading( 'importing' );
 		const data = await importTemplate( item.template_id );
 

--- a/editor/src/components/list-item.js
+++ b/editor/src/components/list-item.js
@@ -35,7 +35,6 @@ const ListItem = ( {
 	const [ itemName, setItemName ] = useState( item.template_name );
 
 	const importItem = async () => {
-		console.log( 'Here' );
 		setLoading( 'importing' );
 		const data = await importTemplate( item.template_id );
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -90,6 +90,7 @@ class Admin {
 	 */
 	private function is_agency_plan() {
 		$category         = apply_filters( 'product_neve_license_plan', - 1 );
+		error_log( var_export( $category, true ) );
 		$category_mapping = array(
 			1 => 1,
 			2 => 1,

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -50,6 +50,13 @@ class Admin {
 		}
 	}
 
+	/**
+	 * Hook into editor data to add Neve plan if available.
+	 *
+	 * @param array $data tiTpc exported data.
+	 *
+	 * @return array
+	 */
 	public function add_tpc_editor_data( $data ) {
 		$plan = $this->neve_license_plan();
 
@@ -92,6 +99,11 @@ class Admin {
 		}
 	}
 
+	/**
+	 * Map license plan from Neve if available.
+	 *
+	 * @return int
+	 */
 	private function neve_license_plan() {
 		$category = apply_filters( 'product_neve_license_plan', - 1 );
 

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -25,6 +25,8 @@ use FLBuilderModel;
 class Rest_Server {
 	/**
 	 * Initialize the rest functionality.
+	 *
+	 * @return void
 	 */
 	public function init() {
 		add_action( 'rest_api_init', array( $this, 'register_endpoints' ) );

--- a/templates-patterns-collection.php
+++ b/templates-patterns-collection.php
@@ -15,7 +15,8 @@
  * @package templates-patterns-collection
  */
 
-add_action( 'admin_notices', 'ti_tpc_plugins_page_notice' );
+// Remove entirely this notice for Independent TPC
+//add_action( 'admin_notices', 'ti_tpc_plugins_page_notice' );
 add_action( 'init', 'ti_tpc_load_textdomain' );
 add_action( 'init', 'ti_tpc_flush_premalinks' );
 

--- a/templates-patterns-collection.php
+++ b/templates-patterns-collection.php
@@ -15,46 +15,8 @@
  * @package templates-patterns-collection
  */
 
-// Remove entirely this notice for Independent TPC
-//add_action( 'admin_notices', 'ti_tpc_plugins_page_notice' );
 add_action( 'init', 'ti_tpc_load_textdomain' );
 add_action( 'init', 'ti_tpc_flush_premalinks' );
-
-/**
- * Plugins page notice if we don't have neve activated.
- */
-function ti_tpc_plugins_page_notice() {
-	if ( defined( 'NEVE_VERSION' ) ) {
-		return;
-	}
-
-	$screen = get_current_screen();
-	if ( ! isset( $screen->id ) ) {
-		return;
-	}
-
-	if ( $screen->id !== 'plugins' ) {
-		return;
-	}
-
-	$notice  = '<div class="notice notice-warning">';
-	$notice .= '<p>';
-	$notice .= sprintf(
-		__( 'You need to have %1$s installed and activated to use %2$s.', 'templates-patterns-collection' ),
-		'<strong>' . ( 'Neve Theme' ) . '</strong>',
-		'<strong>' . ( 'Templates Patterns Collection' ) . '</strong>'
-	);
-	$notice .= '</p>';
-	$notice .= '<p class="actions">';
-	$notice .= '<a class="button button-primary" href="' . esc_url( admin_url( 'theme-install.php?theme=neve' ) ) . '">';
-	/* translators: %s Neve theme name. */
-	$notice .= sprintf( __( 'Install and Activate %s', 'templates-patterns-collection' ), 'Neve' );
-	$notice .= '</a>';
-	$notice .= '</p>';
-	$notice .= '</div>';
-
-	echo wp_kses_post( $notice );
-}
 
 /**
  * Flush the permalinks after import


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- [x] Remove the Notice that Neve is required from Plugins
- [x] I will remove the pop-up when Neve is not present on Starter Sites and add Neve as part of the required Install.
- [x] For Page Templates I will let them import the template without requiring them to have Neve.
- [x] I will ensure that if the Neve Pro license is available, the Template Cloud is available even if the Neve theme is not being used. My Library should be available on other themes if the License is active.
- [x] Show Upsell modal for Page Templates if Neve is not present
- [x] Change Upsell modal for Cloud Library if Neve is not present
- [x] Update Import modal, add a separate section for Theme to make it more obvious that the theme will be replaced.    

### Screenshots
Import Modal when Neve is not installed:
![image](https://user-images.githubusercontent.com/23024731/181007108-8fd74f46-7ac5-4b9b-84f2-ff39e175b97c.png)


Upsell modal when Neve is not present for Page Templates or Cloud Library:
![image](https://user-images.githubusercontent.com/23024731/181007248-f78d97dd-dfad-4b90-92fd-778194d53c64.png)


Upsell modal if Neve is present for Cloud Library:
![image](https://user-images.githubusercontent.com/23024731/181007368-63ad458f-4ef1-453a-8f25-d99b5c8d4b7b.png)



### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Check that TPC works as before with Neve and Neve Pro installed
2. Check that without Neve, the Starter Sites will install Neve and present that on Import
3. Check that without Neve, the Page Templates are not accessible, an Upsell is presented instead
4. Check that without Neve, the Cloud Library has a modified Upsell
5. Check that if you had Neve and Neve Pro active, for Neve Pro use this PR: https://github.com/Codeinwp/neve-pro-addon/pull/2087, see that Cloud Library is available if changing themes.

<!-- Issues that this pull request closes. -->
Closes #154.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
