### PR TITLE
fix: solve plugin activation for recipe card Codeinwp/neve#3523

### DIFF
--- a/includes/Importers/Plugin_Importer.php
+++ b/includes/Importers/Plugin_Importer.php
@@ -47,6 +47,7 @@ class Plugin_Importer {
 		'wpforms-lite'                     => 'wpforms.php',
 		'beaver-builder-lite-version'      => 'fl-builder.php',
 		'wpzoom-addons-for-beaver-builder' => 'wpzoom-bb-addon-pack.php',
+		'recipe-card-blocks-by-wpzoom'     => 'wpzoom-recipe-card.php',
 	);
 
 	public function __construct() {


### PR DESCRIPTION
### Summary
Fixed the file mapping for `Recipe Card Blocks for Gutenberg & Elementor` it prevented activation.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Import the Recipes Starter Site
2. Plugin should be active after import

<!-- Issues that this pull request closes. -->
References: Codeinwp/neve/issues/3523.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
