### PR TITLE
fix: hide free category on pro is active #158

### DIFF
--- a/assets/src/Components/CategoriesTabs.js
+++ b/assets/src/Components/CategoriesTabs.js
@@ -1,3 +1,4 @@
+/* global tiobDash */
 import classnames from 'classnames';
 
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -14,6 +15,13 @@ const CategoriesTabs = ( {
 		<div className="editor-tabs">
 			{ Object.keys( categories ).map( ( key, index ) => {
 				if ( 1 > count[ key ] ) {
+					return null;
+				}
+				if (
+					tiobDash &&
+					tiobDash.isValidLicense === '1' &&
+					'free' === key
+				) {
 					return null;
 				}
 				const classes = classnames( [

--- a/assets/src/Components/CategorySelector.js
+++ b/assets/src/Components/CategorySelector.js
@@ -1,5 +1,5 @@
+/* global tiobDash */
 import classnames from 'classnames';
-import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { Button, Dashicon, Popover } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -39,6 +39,13 @@ const CategorySelector = ( {
 								{ Object.keys( categories ).map(
 									( key, index ) => {
 										if ( key === category ) {
+											return null;
+										}
+										if (
+											tiobDash &&
+											tiobDash.isValidLicense === '1' &&
+											'free' === key
+										) {
 											return null;
 										}
 										if ( 1 > count[ key ] ) {


### PR DESCRIPTION
### Summary
Hide the `Free` category if the Pro license is active.

### Screenshot
![image](https://user-images.githubusercontent.com/23024731/181480138-86fbd84d-3367-4c20-9e31-63be24842b93.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check with Neve installed that the `Free` category on Starter Sites is available
2. Check after License activation that the `Free` category is no longer displayed on the Tabs.

<!-- Issues that this pull request closes. -->
Closes #158.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
