### PR TITLE
fix: improve warning on empty template Codeinwp/templates-cloud#36

### DIFF
--- a/editor/src/extension.js
+++ b/editor/src/extension.js
@@ -182,7 +182,15 @@ const Exporter = () => {
 				const res = await response.json();
 
 				if ( res.message ) {
-					createErrorNotice( res.message, {
+					let message = res.message;
+					if (
+						message === 'Sorry, you are not allowed to do that.'
+					) {
+						message = __(
+							'Could not save template, check that the template is not empty.'
+						);
+					}
+					createErrorNotice( message, {
 						type: 'snackbar',
 					} );
 				} else {
@@ -263,7 +271,15 @@ const Exporter = () => {
 				const res = await response.json();
 
 				if ( res.message ) {
-					createErrorNotice( res.message, {
+					let message = res.message;
+					if (
+						message === 'Sorry, you are not allowed to do that.'
+					) {
+						message = __(
+							'Could not save template, check that the template is not empty.'
+						);
+					}
+					createErrorNotice( message, {
 						type: 'snackbar',
 					} );
 				} else {


### PR DESCRIPTION
### Summary
Changed toast message when saving empty templates if API fails.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Create a fresh instance.
2. Create a new POST with Neve PRO and TPC active
3. Check the message when trying to save an empty template.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-cloud#36.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
