### PR TITLE
Fix/restrict content import

### DIFF
--- a/includes/Importers/Plugin_Importer.php
+++ b/includes/Importers/Plugin_Importer.php
@@ -48,6 +48,7 @@ class Plugin_Importer {
 		'beaver-builder-lite-version'      => 'fl-builder.php',
 		'wpzoom-addons-for-beaver-builder' => 'wpzoom-bb-addon-pack.php',
 		'recipe-card-blocks-by-wpzoom'     => 'wpzoom-recipe-card.php',
+		'restrict-content'                 => 'restrictcontent.php',
 	);
 
 	public function __construct() {

--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -179,7 +179,7 @@ class WP_Import extends WP_Importer {
 				$this->logger->log( $id->get_error_message() );
 				continue;
 			}
-			$this->process_termmeta( $cat, $id['term_id'] );
+			$this->process_termmeta( $cat, $id );
 		}
 		unset( $this->categories );
 		$this->logger->log( 'Processed categories.', 'success' );


### PR DESCRIPTION
### Summary
Added restricted content plugin mapping.
Fixed an error that was showing in the logs on category import.

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Import Finance Blog Starter Site from staging
2. Check that Restrict Content plugin is active

<!-- Issues that this pull request closes. -->
References Codeinwp/neve-pro-addon#2089.
References Codeinwp/demo-data-exporter/pull/122.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
