### PR TITLE
Feat/mark premium imports

### DIFF
--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -31,6 +31,7 @@ import {
 	PanelBody,
 	PanelRow,
 } from '@wordpress/components';
+import {removeImportType, setImportType} from "./SettingsApi";
 
 const ImportModal = ( {
 	setModal,
@@ -346,8 +347,10 @@ const ImportModal = ( {
 					return false;
 				}
 				console.log( '[D] Cleanup.' );
-				setCleanupProgress( 'done' );
-				runImport();
+				removeImportType().then( r => {
+					setCleanupProgress( 'done' );
+					runImport();
+				} );
 			} )
 			.catch( ( incomingError ) =>
 				handleError( incomingError, 'cleanup' )
@@ -464,8 +467,10 @@ const ImportModal = ( {
 				if ( response.frontpage_id ) {
 					setFrontPageID( response.frontpage_id );
 				}
-				setContentProgress( 'done' );
-				runImportCustomizer();
+				setImportType( siteData ).then( r => {
+					setContentProgress( 'done' );
+					runImportCustomizer();
+				} );
 			} )
 			.catch( ( incomingError ) =>
 				handleError( incomingError, 'content' )

--- a/assets/src/Components/SettingsApi.js
+++ b/assets/src/Components/SettingsApi.js
@@ -1,0 +1,45 @@
+/*eslint import/no-unresolved: [2, { ignore: ['@wordpress/api'] }]*/
+import { loadPromise, models } from '@wordpress/api';
+
+export const fetchOptions = () => {
+    let settings;
+    return loadPromise.then(() => {
+        settings = new models.Settings();
+        return settings.fetch();
+    });
+};
+
+export const fetchOption = ( option ) => {
+    return fetchOptions().then((r) => {
+        return r.hasOwnProperty(option) ? r[option] : null;
+    });
+}
+
+export const changeOption = (option, value) => {
+    const model = new models.Settings({
+        [option]: value,
+    });
+
+    return new Promise((resolve) => {
+        model.save().then((r) => {
+            if (!r || !r[option] === value) {
+                resolve({ success: false });
+            }
+            resolve({ success: true });
+        });
+    });
+};
+
+export const setImportType = async ( siteData ) => {
+    const optionName = 'templates_patterns_collection_pro_import';
+    if ( siteData.hasOwnProperty('upsell') ) {
+        await changeOption( optionName, true );
+        return await fetchOption( optionName );
+    }
+};
+
+export const removeImportType = async () => {
+    const optionName = 'templates_patterns_collection_pro_import';
+    await changeOption( optionName, false );
+    return await fetchOption( optionName );
+};

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -115,6 +115,16 @@ class Main {
 		$this->setup_admin();
 		$this->setup_api();
 		$this->setup_active_state();
+
+		register_setting(
+			'tpc_premium_import',
+			'templates_patterns_collection_pro_import',
+			array(
+				'type'         => 'boolean',
+				'show_in_rest' => true,
+				'default'      => false,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Add a flag on import if a premium starter site is imported.
Remove the flag on cleanup.


### Test instructions
<!-- Describe how this pull request can be tested. -->
Use this PR: https://github.com/Codeinwp/neve/pull/3670 to test with.

1. Import a premium Starter Site
2. Check that if you have no Neve Pro License available the Notice is present inside Neve Dashboard.
3. Check that if Neve Pro is not present the Notice is present inside Neve Dashboard
4. Import a free Starter Site and use Cleanup during the import
5. Check that for 2. and 3. the Notice is not present anymore.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2018.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
