### PR TITLE
Add performance features step in demo import

### DIFF
--- a/assets/src/Components/CustomTooltip.js
+++ b/assets/src/Components/CustomTooltip.js
@@ -1,24 +1,20 @@
-import { Button, Icon } from '@wordpress/components';
-import { useState } from '@wordpress/element';
-import { info } from '@wordpress/icons';
+import { Icon, info } from '@wordpress/icons';
 
 import classnames from 'classnames';
 
-const CustomTooltip = ( { children, className } ) => {
+const CustomTooltip = ( { children, className, toLeft = false } ) => {
 	const tooltipClassNames = classnames( [ className, 'tiob-tooltip-wrap' ] );
+
+	const ttStyle = toLeft ? { right: 0, left: 'unset' } : {};
 
 	return (
 		<div className={ tooltipClassNames }>
-			<Button
-				onClick={ ( e ) => {
-					e.preventDefault();
-				} }
-				className="tiob-tooltip-toggle"
-				icon={ info }
-				isLink
-				isSmall
-			/>
-			<div className="tiob-tooltip-content">{ children }</div>
+			<div className="tiob-tooltip-toggle">
+				<Icon icon={ info } size={ 24 } />
+				<div className="tiob-tooltip-content" style={ ttStyle }>
+					{ children }
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -285,6 +285,10 @@ const ImportModal = ( {
 			...( importData.mandatory_plugins || {} ),
 		};
 
+		if ( Object.keys( allPlugins ).length < 1 ) {
+			return null;
+		}
+
 		const toggleOpen = () => {
 			setPluginsOpened( ! pluginsOpened );
 		};

--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -480,10 +480,7 @@ const ImportModal = ( {
 		}
 		setCurrentStep( 'plugins' );
 		console.log( '[P] Plugins.' );
-		installPlugins( {
-			...pluginOptions,
-			'optimole-wp': general.performanceAddon,
-		} )
+		installPlugins( pluginOptions )
 			.then( ( response ) => {
 				if ( ! response.success ) {
 					handleError( response, 'plugins' );
@@ -581,7 +578,6 @@ const ImportModal = ( {
 			);
 	}
 	function runPerformanceAddonInstall() {
-		importDone();
 		if ( ! general.performanceAddon ) {
 			console.log( '[S] Performance Addon.' );
 			importDone();

--- a/assets/src/Components/ImportStepper.js
+++ b/assets/src/Components/ImportStepper.js
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 
 import { __ } from '@wordpress/i18n';
 import { Dashicon } from '@wordpress/components';
+
 const ImportStepper = ( { currentStep, progress, willDo } ) => {
 	const stepsMap = {
 		cleanup: {
@@ -42,6 +43,14 @@ const ImportStepper = ( { currentStep, progress, willDo } ) => {
 			label: __( 'Importing Widgets', 'templates-patterns-collection' ),
 			status: progress.widgets,
 			willDo: willDo.widgets,
+		},
+		performanceAddon: {
+			label: __(
+				'Installing Performance Features',
+				'templates-patterns-collection'
+			),
+			status: progress.performanceAddon,
+			willDo: willDo.performanceAddon,
 		},
 	};
 

--- a/assets/src/scss/_custom-tooltip.scss
+++ b/assets/src/scss/_custom-tooltip.scss
@@ -1,30 +1,37 @@
 .tiob-tooltip-wrap {
-	position: relative;
-	display: flex;
-	align-items: center;
-	margin-left: 10px;
+  margin-left: 10px;
 
-	.tiob-tooltip-toggle {
-		&:hover, &:focus {
-			outline: none;
-			box-shadow: none;
-			+ .tiob-tooltip-content {
-				opacity: 1;
-				pointer-events: all;
-				z-index: 1;
-			}
-		}
-	}
+  .tiob-tooltip-toggle {
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    > svg {
+      fill: $blue;
+    }
+
+    &:hover, &:focus {
+      outline: none;
+      box-shadow: none;
+
+      .tiob-tooltip-content {
+        opacity: 1;
+        pointer-events: all;
+      }
+    }
+  }
 }
 
 .tiob-tooltip-content {
-	top: 100%;
-	left: 0;
-	position: absolute;
-	min-width: 300px;
-	background: #fff;
-	box-shadow: rgba(99, 99, 99, 0.2) 0 2px 8px 0;
-	padding: 10px;
-	pointer-events: none;
-	opacity: 0;
+  font-size: 13px;
+  top: 100%;
+  left: 0;
+  position: absolute;
+  min-width: 300px;
+  background: #fff;
+  box-shadow: rgba(99, 99, 99, 0.2) 0 2px 8px 0;
+  padding: 10px;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0;
 }

--- a/assets/src/scss/_import-modal.scss
+++ b/assets/src/scss/_import-modal.scss
@@ -272,11 +272,6 @@ $base-index: 100000;
 			font-size: 17px;
 			font-weight: 700;
 			line-height: 30px;
-
-			svg {
-				width: 30px;
-				height: 30px;
-			}
 		}
 	}
 

--- a/includes/Importers/Cleanup/Manager.php
+++ b/includes/Importers/Cleanup/Manager.php
@@ -21,6 +21,8 @@ class Manager {
 	 */
 	protected static $instance = null;
 
+	const OPTIMOLE_SLUG = 'optimole-wp';
+
 	/**
 	 * Instantiate the class.
 	 *
@@ -81,7 +83,9 @@ class Manager {
 	 */
 	private function get_plugin_key_by_slug( $plugin_slug, $plugin_list ) {
 		foreach ( $plugin_list as $key => $data ) {
-			if ( isset( $data['Name'] ) && sanitize_title( $data['Name'] ) === $plugin_slug ) {
+			$parts = explode( '/', $key );
+
+			if ( isset( $parts[0] ) && $parts[0] === $plugin_slug ) {
 				return $key;
 			}
 		}
@@ -96,6 +100,10 @@ class Manager {
 		if ( isset( $state[ Active_State::PLUGINS_NSP ] ) ) {
 			$plugin_list = get_plugins();
 			foreach ( $state[ Active_State::PLUGINS_NSP ] as $plugin_slug => $info ) {
+				if ( $plugin_slug === self::OPTIMOLE_SLUG ) {
+					return;
+				}
+
 				$plugin = $this->get_plugin_key_by_slug( $plugin_slug, $plugin_list );
 				if ( empty( $plugin ) ) {
 					continue;

--- a/includes/Importers/Cleanup/Manager.php
+++ b/includes/Importers/Cleanup/Manager.php
@@ -8,6 +8,8 @@
  */
 namespace TIOB\Importers\Cleanup;
 
+use TIOB\Importers\Plugin_Importer;
+
 /**
  * Class Manager
  * @package TIOB\Importers\Cleanup
@@ -20,8 +22,6 @@ class Manager {
 	 * @var Manager
 	 */
 	protected static $instance = null;
-
-	const OPTIMOLE_SLUG = 'optimole-wp';
 
 	/**
 	 * Instantiate the class.
@@ -100,7 +100,7 @@ class Manager {
 		if ( isset( $state[ Active_State::PLUGINS_NSP ] ) ) {
 			$plugin_list = get_plugins();
 			foreach ( $state[ Active_State::PLUGINS_NSP ] as $plugin_slug => $info ) {
-				if ( $plugin_slug === self::OPTIMOLE_SLUG ) {
+				if ( $plugin_slug === Plugin_Importer::OPTIMOLE_SLUG ) {
 					return;
 				}
 

--- a/includes/Importers/Plugin_Importer.php
+++ b/includes/Importers/Plugin_Importer.php
@@ -20,6 +20,9 @@ use WP_REST_Response;
  */
 class Plugin_Importer {
 
+	const OPTIMOLE_FRESH_INSTALL_FLAG = 'optml_fresh_install';
+	const OPTIMOLE_SLUG               = 'optimole-wp';
+
 	/**
 	 * Log
 	 *
@@ -206,7 +209,7 @@ class Plugin_Importer {
 			)
 		);
 
-		if ( version_compare( PHP_VERSION, '5.6' ) === -1 ) {
+		if ( version_compare( PHP_VERSION, '5.6' ) === - 1 ) {
 			$skin = new Quiet_Skin_Legacy(
 				array(
 					'api' => $api,
@@ -323,6 +326,10 @@ class Plugin_Importer {
 		activate_plugin( $plugin_path );
 		$this->log .= 'Activated ' . ucwords( $plugin_slug ) . '.' . "\n";
 
+		if ( $plugin_slug === self::OPTIMOLE_SLUG ) {
+			delete_transient( self::OPTIMOLE_FRESH_INSTALL_FLAG );
+		}
+
 		do_action( 'themeisle_ob_after_single_plugin_activation', $plugin_slug );
 
 		return true;
@@ -347,6 +354,7 @@ class Plugin_Importer {
 	 * Filter pages from woocommerce activation.
 	 *
 	 * @param array $pages List of pages to be created on activation.
+	 *
 	 * @return array
 	 */
 	public function woocommerce_activation_pages( $pages ) {


### PR DESCRIPTION
### Summary
- Disables plugins panel in import modal if there are no plugins (this bug can be seen on the Neve 3 demo in the current version);
- Adds performance features step to the import modal that installs OptiMole;
- Optimole **won't** be removed when running a cleanup;
- After we merge [this PR](https://github.com/Codeinwp/optimole-wp/pull/451), OptiMole should not redirect to its' dashboard after installation;
<!-- Please describe the changes you made. -->

![image](https://user-images.githubusercontent.com/15010186/199209255-e4bb5b20-a31d-4100-b134-e2f27ae613d3.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the Neve 3 demo. The import modal should have no **Plugins** panel as it doesn't add any plugin;
- All imports should have an additional toggle in the **Import settings** panel;
- When this step is enabled, the import will also install OptiMole;
- When a cleanup happens (i.e., when you disable everything in the import modal but enable the `Cleanup previous import` step), OptiMole will not be removed;

---

Additional things:

- On a fresh instance, add OptiMole from [this PR](https://github.com/Codeinwp/optimole-wp/pull/451) to the `plugins` folder;
- Import a demo with the new step enabled;
- Optimole should not redirect to its dashboard, but you should see the notice mentioned in the PR above across the dashboard until you dismiss it or go to the OptiMole dashboard page;

<!-- Issues that this pull request closes. -->
Closes #172.
Closes Codeinwp/demo-data-exporter#135.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
