### PR TITLE
Fix/elementor template button language fix

### DIFF
--- a/elementor/src/import.js
+++ b/elementor/src/import.js
@@ -65,11 +65,11 @@ const placeholder = document.getElementById( 'tmpl-elementor-add-section' );
 
 if ( placeholder ) {
 	const text = placeholder.textContent;
+	const regex = /(<div class="[^"]*?elementor-add-section-drag-title[^"]*?">(.|\n)*?<\/div>)/gm;
 	placeholder.textContent = text.replace(
+		regex,
 		// eslint-disable-next-line prettier/prettier
-		'<div class=\"elementor-add-section-drag-title\">Drag widget here</div>',
-		// eslint-disable-next-line prettier/prettier
-		`<div class="elementor-add-section-area-button elementor-templates-cloud-button" title="${ window.tiTpc.library.libraryButton }"><svg width="100" height="100" viewBox="10 10 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="tpc-template-cloud-icon" role="img" aria-hidden="true" focusable="false"><path d="M95.0264 100H4.97356C2.22797 100 0 97.772 0 95.0264V4.97356C0 2.22797 2.22797 0 4.97356 0H95.0264C97.772 0 100 2.22797 100 4.97356V95.0264C100 97.772 97.772 100 95.0264 100Z" fill="#0366D6"></path><path d="M82.6941 86.7448V30.8205V18.4653H70.3502H14.4146L26.7584 30.8205H70.3502V74.401L82.6941 86.7448Z" fill="white"></path><path d="M42.2416 58.9291L42.2528 71.183L53.2352 82.1653L53.1902 47.9806L18.9941 47.9355L29.9765 58.9066L42.2416 58.9291Z" fill="white" style=""></path></svg></div> <div class=\"elementor-add-section-drag-title\">Drag widget here</div>`
+		`<div class="elementor-add-section-area-button elementor-templates-cloud-button" title="${ window.tiTpc.library.libraryButton }"><svg width="100" height="100" viewBox="10 10 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="tpc-template-cloud-icon" role="img" aria-hidden="true" focusable="false"><path d="M95.0264 100H4.97356C2.22797 100 0 97.772 0 95.0264V4.97356C0 2.22797 2.22797 0 4.97356 0H95.0264C97.772 0 100 2.22797 100 4.97356V95.0264C100 97.772 97.772 100 95.0264 100Z" fill="#0366D6"></path><path d="M82.6941 86.7448V30.8205V18.4653H70.3502H14.4146L26.7584 30.8205H70.3502V74.401L82.6941 86.7448Z" fill="white"></path><path d="M42.2416 58.9291L42.2528 71.183L53.2352 82.1653L53.1902 47.9806L18.9941 47.9355L29.9765 58.9066L42.2416 58.9291Z" fill="white" style=""></path></svg></div> $1`
 	);
 }
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Changed the replacement target for the import Elementor button for Templates Cloud

![image](https://user-images.githubusercontent.com/23024731/199237839-e21c89f7-7e27-4a06-9e80-bf91be91ab38.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Follow the steps from here to test: https://github.com/Codeinwp/neve-pro-addon/issues/2232

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2232.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
