### PR TITLE
fix: import modal white space #175

### DIFF
--- a/editor/src/editor.scss
+++ b/editor/src/editor.scss
@@ -9,6 +9,10 @@
 
 		.components-modal__content {
 			padding: 0;
+			margin-top: 0;
+			&:before {
+				margin-bottom: 0;
+			}
 
 			.components-modal__header {
 				display: none;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixes import modal white space

![image](https://user-images.githubusercontent.com/23024731/199951718-638a6661-bd5f-44e8-af9e-d953dac93cdb.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a new post or a page
2. Try to import a template using the Templates Cloud block
3. Check how the import modal works.


<!-- Issues that this pull request closes. -->
Closes #175.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
