### PR TITLE
fix: dismiss neve notice after ss content import #178

### DIFF
--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -185,6 +185,9 @@ class Rest_Server {
 		$content_importer = new Content_Importer();
 		$import           = $content_importer->import_remote_xml( $request );
 		set_transient( 'ti_tpc_should_flush_permalinks', 'yes', 12 * HOUR_IN_SECONDS );
+		if ( get_option( 'neve_notice_dismissed', 'no' ) !== 'yes' ) {
+			update_option( 'neve_notice_dismissed', 'yes' );
+		}
 
 		return $import;
 	}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Hide Neve welcome notice for starter sites once a starter site content is imported.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check on a fresh instance that once you import a Starter Site the Neve welcome notice will be displayed.

<!-- Issues that this pull request closes. -->
Closes #178.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
