### PR TITLE
fix: increase modal max-height to 90vh #177

### DIFF
--- a/assets/src/scss/_general.scss
+++ b/assets/src/scss/_general.scss
@@ -22,12 +22,14 @@
 @media screen and (min-width: #{$tablet}) {
 	.ob-import-modal {
 		width: 630px !important;
+		max-height: 90vh;
 	}
 }
 
 @media screen and (min-width: #{$laptop}) {
 	.ob-import-modal {
 		width: 700px !important;
+		max-height: 90vh;
 	}
 }
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Increase the modal `max-height` and change the unit used to `vh`
This will prevent the scrollbar from appearing in most cases, one exception will still remain to have a large number of plugins listed. That issue will be addressed here:  #146

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that scrollbars are not present if importing a Starter Site without Neve installed and with 1-3 plugins active.

<!-- Issues that this pull request closes. -->
Closes #177.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
