### PR TITLE
fix: improved modal display on small screens and with multiple options

### DIFF
--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -147,16 +147,6 @@ const ImportModal = ( {
 
 	const ModalHead = () => (
 		<div className="header">
-			<h1>
-				{ sprintf(
-					/* translators: name of starter site */
-					__(
-						'Import %s as a complete site',
-						'templates-patterns-collection'
-					),
-					importData.title
-				) }
-			</h1>
 			<p className="description">
 				{ __(
 					'Import the entire site including customizer options, pages, content and plugins.',
@@ -729,6 +719,16 @@ const ImportModal = ( {
 			onRequestClose={ closeModal }
 			shouldCloseOnClickOutside={ ! importing && ! fetching }
 			isDismissible={ ! importing && ! fetching }
+			title={ importData ?
+				sprintf(
+					/* translators: name of starter site */
+					__(
+						'Import %s as a complete site',
+						'templates-patterns-collection'
+					),
+					importData.title
+				) : ''
+			}
 		>
 			{ fetching ? (
 				<ImportModalMock />

--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -70,7 +70,6 @@ const ImportModal = ( {
 	const [ error, setError ] = useState( null );
 	const [ importData, setImportData ] = useState( null );
 	const [ fetching, setFetching ] = useState( true );
-	const [ pluginsOpened, setPluginsOpened ] = useState( true );
 	const [ optionsOpened, setOptionsOpened ] = useState( true );
 	const [ themeOpened, setThemeOpened ] = useState( true );
 
@@ -341,48 +340,68 @@ const ImportModal = ( {
 			return null;
 		}
 
+		const [ pluginsOpened, setPluginsOpened ] = useState( Object.keys( allPlugins ).length < 3 );
+
 		const toggleOpen = () => {
 			setPluginsOpened( ! pluginsOpened );
 		};
 
+		const pluginsList = Object.keys( allPlugins ).map( ( slug, index ) => {
+			return allPlugins[ slug ];
+		} ).join( ', ' );
+
 		return (
-			<PanelBody
-				onToggle={ toggleOpen }
-				opened={ pluginsOpened }
-				className="options plugins"
-				title={ __( 'Plugins', 'templates-patterns-collection' ) }
-			>
-				{ Object.keys( allPlugins ).map( ( slug, index ) => {
-					const rowClass = classnames( 'option-row', {
-						active: pluginOptions[ slug ],
-					} );
-					return (
-						<PanelRow className={ rowClass } key={ index }>
-							<Icon icon="admin-plugins" />
-							<span
-								dangerouslySetInnerHTML={ {
-									__html: allPlugins[ slug ],
-								} }
-							/>
-							{ slug in importData.recommended_plugins && (
-								<div className="toggle-wrapper">
-									<ToggleControl
-										checked={ pluginOptions[ slug ] }
-										onChange={ () => {
-											setPluginOptions( {
-												...pluginOptions,
-												[ slug ]: ! pluginOptions[
-													slug
-												],
-											} );
-										} }
-									/>
-								</div>
-							) }
-						</PanelRow>
-					);
-				} ) }
-			</PanelBody>
+			<>
+				<PanelBody
+					onToggle={ toggleOpen }
+					opened={ pluginsOpened }
+					className="options plugins"
+					title={ __( 'Plugins', 'templates-patterns-collection' ) }
+				>
+					{ Object.keys( allPlugins ).map( ( slug, index ) => {
+						const rowClass = classnames( 'option-row', {
+							active: pluginOptions[ slug ],
+						} );
+						return (
+							<PanelRow className={ rowClass } key={ index }>
+								<Icon icon="admin-plugins" />
+								<span
+									dangerouslySetInnerHTML={ {
+										__html: allPlugins[ slug ],
+									} }
+								/>
+								{ slug in importData.recommended_plugins && (
+									<div className="toggle-wrapper">
+										<ToggleControl
+											checked={ pluginOptions[ slug ] }
+											onChange={ () => {
+												setPluginOptions( {
+													...pluginOptions,
+													[ slug ]: ! pluginOptions[
+														slug
+													],
+												} );
+											} }
+										/>
+									</div>
+								) }
+							</PanelRow>
+						);
+					} ) }
+				</PanelBody>
+				{ ! pluginsOpened && (<i className="plugin-summary">
+					<CustomTooltip
+						toLeft={false}
+					>
+						<span
+							dangerouslySetInnerHTML={ {
+								__html: pluginsList,
+							} }
+						/>
+					</CustomTooltip>
+					{ __( 'Additional plugins are required for this Starter Site in order to work properly. ', 'templates-patterns-collection' ) }
+				</i>) }
+			</>
 		);
 	};
 

--- a/assets/src/scss/_custom-tooltip.scss
+++ b/assets/src/scss/_custom-tooltip.scss
@@ -17,6 +17,7 @@
       .tiob-tooltip-content {
         opacity: 1;
         pointer-events: all;
+        z-index: 11;
       }
     }
   }

--- a/assets/src/scss/_general.scss
+++ b/assets/src/scss/_general.scss
@@ -28,6 +28,7 @@
 @media screen and (min-width: #{$laptop}) {
 	.ob-import-modal {
 		width: 700px !important;
+		max-height: 90vh;
 	}
 }
 

--- a/assets/src/scss/_import-modal.scss
+++ b/assets/src/scss/_import-modal.scss
@@ -129,10 +129,35 @@ $base-index: 100000;
 		font-size: 15px;
 	}
 
+	.modal-body {
+		padding-bottom: 42px;
+
+		.plugin-summary {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			.tiob-tooltip-content {
+				left: 25px;
+				top: 0;
+			}
+		}
+	}
+
 	.modal-footer {
 		margin-top: 25px;
 		display: flex;
 		align-items: center;
+		position: absolute;
+		bottom: 0;
+		background: #fff;
+		width: calc( 100% - 72px );
+		padding: 12px 36px;
+		z-index: 10;
+		left: 0;
+		border-top: 1px solid #d9d9d9;
+
+		-webkit-box-shadow: 0px -24px 12px 0px rgba(255,255,255,0.8);
+		box-shadow: 0px -24px 12px 0px rgba(255,255,255,0.8);
 
 		.import {
 			padding: 10px 30px;

--- a/assets/src/scss/_import-modal.scss
+++ b/assets/src/scss/_import-modal.scss
@@ -34,6 +34,11 @@ $base-index: 100000;
 	}
 	.components-modal__header {
 		border: none;
+
+		h1 {
+			font-size: 22px;
+			font-weight: 700;
+		}
 	}
 
 	.header {
@@ -49,9 +54,9 @@ $base-index: 100000;
 		}
 
 		p.description {
-			font-size: 17px;
+			font-size: 15px;
 			line-height: 34px;
-			color: #000;
+			color: #333;
 		}
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Increased the modal `max-width` to `90vh`
Fixed footer section for modal.
Collapse plugins section if more than 2 plugins and show an information text with what will be installed.

If the screen size is very small I added a white shadow to fade content in to suggest that more items are available to scroll.

@Codeinwp/design-team 
cc: @selul, @abaicus 
Let me know what you think about these changes for the modal, I tried to solve both issues with these changes, allow the user to easily import a starter site if he does not require any changes while also maintaining accessibility and existing functionality. 

You can add your feedback here and I will implement the required changes.
Thank you!

### Screenshots
#### Modal on 800px height laptop with more than 2 plugins collapsed
![image](https://user-images.githubusercontent.com/23024731/200558744-4de20c16-fc9d-4b14-b0cb-8ccbde921e81.png)

#### Modal on 800px height laptop with more than 2 plugins collapsed info hover
![image](https://user-images.githubusercontent.com/23024731/200558946-13a24c2e-5f9d-4ae2-a265-ae4e3591ea71.png)

#### Modal on 800px height laptop with more than 2 plugins opened
![image](https://user-images.githubusercontent.com/23024731/200559051-f8e8100f-2b40-4d8c-a5e8-5b8a23d5d588.png)

#### Modal on 640px height laptop
![image](https://user-images.githubusercontent.com/23024731/200559342-2d39889d-f278-471e-9c87-7317598efcd9.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check how the modal looks for different imports
2. Ensure that Import is always available

References: #146
<!-- Issues that this pull request closes. -->
Closes #180.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
