### PR TITLE
chore: added subscribe form after import

### DIFF
--- a/assets/src/scss/_general.scss
+++ b/assets/src/scss/_general.scss
@@ -27,7 +27,7 @@
 
 @media screen and (min-width: #{$laptop}) {
 	.ob-import-modal {
-		width: 700px !important;
+		width: 540px !important;
 		max-height: 90vh;
 	}
 }

--- a/assets/src/scss/_import-modal.scss
+++ b/assets/src/scss/_import-modal.scss
@@ -36,7 +36,7 @@ $base-index: 100000;
 		border: none;
 
 		h1 {
-			font-size: 22px;
+			font-size: 18px;
 			font-weight: 700;
 		}
 	}
@@ -46,7 +46,7 @@ $base-index: 100000;
 
 		h1 {
 			margin-top: 0;
-			font-size: 22px;
+			font-size: 18px;
 			font-weight: 700;
 			color: #000;
 			line-height: normal;
@@ -54,8 +54,8 @@ $base-index: 100000;
 		}
 
 		p.description {
-			font-size: 15px;
-			line-height: 34px;
+			font-size: 14px;
+			line-height: 24px;
 			color: #333;
 		}
 	}
@@ -89,7 +89,7 @@ $base-index: 100000;
 
 			li {
 				margin-bottom: 10px;
-				font-size: 15px;
+				font-size: 14px;
 
 				&:last-child {
 					margin-bottom: 0;
@@ -103,7 +103,7 @@ $base-index: 100000;
 			list-style: disc;
 
 			li {
-				font-size: 15px;
+				font-size: 14px;
 				margin-bottom: 10px;
 				font-weight: 400;
 
@@ -131,7 +131,7 @@ $base-index: 100000;
 	}
 
 	.import-result {
-		font-size: 15px;
+		font-size: 14px;
 	}
 
 	.modal-body {
@@ -144,6 +144,20 @@ $base-index: 100000;
 			.tiob-tooltip-content {
 				left: 25px;
 				top: 0;
+			}
+		}
+
+		.tpc-subscribe-email-text {
+			font-size: 14px;
+			margin-top: 20px;
+		}
+		.tpc-email-input {
+			margin-bottom: 60px;
+			input {
+				padding: 12px;
+				font-size: 13px;
+				color: #2C3338;
+				border-radius: 2px;
 			}
 		}
 	}
@@ -299,7 +313,7 @@ $base-index: 100000;
 		}
 
 		button {
-			font-size: 17px;
+			font-size: 16px;
 			font-weight: 700;
 			line-height: 30px;
 		}
@@ -309,13 +323,13 @@ $base-index: 100000;
 		justify-content: flex-start;
 		border-bottom: 1px solid transparentize($black, .9);
 		margin: 0;
-		padding: 10px 0;
+		padding: 8px 0;
 		display: flex;
 		align-items: center;
 
 		span {
-			font-size: 15px;
-			margin-left: 20px;
+			font-size: 14px;
+			margin-left: 10px;
 			color: $black;
 		}
 
@@ -349,6 +363,9 @@ $base-index: 100000;
 	display: flex;
 	align-items: center;
 	width: 100%;
+	flex-direction: column-reverse;
+	gap: 10px;
+	padding: 12px 0;
 
 	.components-button.is-secondary {
 		margin-left: auto;
@@ -361,6 +378,14 @@ $base-index: 100000;
 	}
 
 	.import {
-		margin-left: 20px !important;
+		margin-left: 0 !important;
+	}
+	.import-full-w {
+		width: 100%;
+		justify-content: center;
+		padding: 12px 30px;
+	}
+	.is-grayed {
+		color: #757575;
 	}
 }

--- a/assets/src/scss/_stepper.scss
+++ b/assets/src/scss/_stepper.scss
@@ -2,8 +2,8 @@
 	li {
 		display: flex;
 		align-items: center;
-		margin-bottom: 25px;
-		font-size: 15px;
+		margin-bottom: 20px;
+		font-size: 14px;
 
 		.icon {
 			margin-right: 20px;
@@ -11,6 +11,13 @@
 			color: #fff;
 			padding: 5px;
 			border-radius: 100%;
+			line-height: 14px;
+
+			.dashicon {
+				font-size: 14px;
+				width: 14px;
+				height: 14px;
+			}
 
 			&.success {
 				background-color: $success;
@@ -42,8 +49,8 @@
 		}
 
 		svg {
-			width: 20px;
-			height: 20px;
+			width: 15px;
+			height: 15px;
 			display: block;
 		}
 	}

--- a/assets/src/utils/rest.js
+++ b/assets/src/utils/rest.js
@@ -33,3 +33,25 @@ const requestData = async (
 		return simple ? response : response.json();
 	} );
 };
+
+export const ajaxAction = async (route, action = '', useNonce = '', data = {} ) => {
+	const formData = new FormData();
+	formData.append('nonce', useNonce);
+	formData.append('action', action);
+	if ( Object.keys( data ).length > 0 ) {
+		for ( const [key, value] of Object.entries( data ) ) {
+			formData.append( key, value );
+		}
+	}
+	const options = {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+		},
+		body: formData,
+	};
+
+	return await fetch(route, options).then(() => {
+		return true;
+	});
+};

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -31,6 +31,13 @@ class Admin {
 	private $wl_config = null;
 
 	/**
+	 * Option and transient namespace for email skip.
+	 *
+	 * @var string
+	 */
+	private $skip_email_subscribe_namespace = 'tpc_skip_email_subscribe';
+
+	/**
 	 * Initialize the Admin.
 	 */
 	public function init() {
@@ -48,6 +55,70 @@ class Admin {
 				$this->wl_config = json_decode( $branding, true );
 			}
 		}
+
+		add_action( 'wp_ajax_skip_subscribe', array( $this, 'skip_subscribe' ) );
+		add_action( 'wp_ajax_nopriv_skip_subscribe', array( $this, 'skip_subscribe' ) );
+	}
+
+	/**
+	 * Return the skip subscribe status.
+	 * Used to determine if email form should be displayed.
+	 *
+	 * @return bool
+	 */
+	private function get_skip_subscribe_status() {
+		$status = false;
+		if ( 'yes' === get_option( $this->skip_email_subscribe_namespace, 'no' ) ) {
+			$status = true;
+		}
+
+		if ( get_transient( $this->skip_email_subscribe_namespace ) ) {
+			$status = true;
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Utility method to ensure proper response for ajax call.
+	 *
+	 * @param array $response
+	 */
+	private function ensure_ajax_response( $response ) {
+		echo json_encode( $response );
+		die();
+	}
+
+	/**
+	 * Handles the `skip_subscribe` ajax action.
+	 */
+	public function skip_subscribe() {
+		$response = array(
+			'success' => false,
+			'code'    => 'ti__ob_not_allowed',
+			'message' => 'Not allowed!',
+		);
+		if ( ! isset( $_REQUEST['nonce'] ) ) {
+			$this->ensure_ajax_response( $response );
+			return;
+		}
+
+		if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'skip_subscribe_nonce' ) ) {
+			$this->ensure_ajax_response( $response );
+			return;
+		}
+
+		unset( $response['code'] );
+		unset( $response['message'] );
+		$response['success'] = true;
+		if ( isset( $_REQUEST['isTempSkip'] ) ) {
+			set_transient( $this->skip_email_subscribe_namespace, 'yes', 7 * DAY_IN_SECONDS );
+			$this->ensure_ajax_response( $response );
+			return;
+		}
+
+		update_option( $this->skip_email_subscribe_namespace, 'yes' );
+		$this->ensure_ajax_response( $response );
 	}
 
 	/**
@@ -173,6 +244,7 @@ class Admin {
 	 */
 	private function get_localization() {
 		$theme_name = apply_filters( 'ti_wl_theme_name', 'Neve' );
+		$user       = wp_get_current_user();
 
 		return array(
 			'nonce'               => wp_create_nonce( 'wp_rest' ),
@@ -195,6 +267,12 @@ class Admin {
 			),
 			'upsellNotifications' => $this->get_upsell_notifications(),
 			'isValidLicense'      => $this->has_valid_addons(),
+			'emailSubscribe'      => array(
+				'ajaxURL'    => esc_url( admin_url( 'admin-ajax.php' ) ),
+				'nonce'      => wp_create_nonce( 'skip_subscribe_nonce' ),
+				'skipStatus' => $this->get_skip_subscribe_status() ? 'yes' : 'no',
+				'email'      => ( ! empty( $user ) ) ? $user->user_email : '',
+			),
 		);
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added a subscribe form after import.
The form will not be displayed for 7 days if skipped.
If subscribed it is dismissed forever.

Changed the styles for the modal, font sizes and spacing is smaller now.

### Screenshots
![image](https://user-images.githubusercontent.com/23024731/202249644-64cf4c7a-f77d-4c5d-a8af-eb4faad67eee.png)

![image](https://user-images.githubusercontent.com/23024731/202249852-8fbc40aa-b408-4ac3-aac1-b842a2cbed58.png)

![image](https://user-images.githubusercontent.com/23024731/202249918-d28c2992-319c-47e7-994c-e4736251c902.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Import a starter site
2. Check that the form is not displayed if `Skip and add your own content` is clicked.
3. Reset the instance ( remove `tpc_skip_email_subscribe` transient )
4. Import a starter site
5. Check that you are subscribed and redirected corectly.
6. Check other modals and possible issues.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve#3672.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
