### PR TITLE
Fix image size generation on import

### DIFF
--- a/includes/Importers/Helpers/Importer_Alterator.php
+++ b/includes/Importers/Helpers/Importer_Alterator.php
@@ -55,9 +55,26 @@ class Importer_Alterator {
 		add_filter( 'wp_import_terms', array( $this, 'skip_terms' ), 10 );
 		add_filter( 'wp_insert_post_data', array( $this, 'encode_post_content' ), 10, 2 );
 		add_filter( 'wp_import_nav_menu_item_args', array( $this, 'change_nav_menu_item_link' ), 10, 2 );
-		add_filter( 'intermediate_image_sizes_advanced', '__return_null' );
+		add_filter( 'intermediate_image_sizes_advanced', array( $this, 'filter_sizes' ), 10, 1 );
 		add_filter( 'tpc_post_content_before_insert', array( $this, 'replace_links' ), 10, 2 );
 		add_filter( 'tpc_post_content_processed_terms', array( $this, 'content_to_import' ), 10, 2 );
+	}
+
+	/**
+	 * Filter the sizes array on image attachment to only default sizes.
+	 *
+	 * @param array $new_sizes The sizes array to use when resizing.
+	 *
+	 * @return array
+	 */
+	public function filter_sizes( $new_sizes ) {
+		return array_filter(
+			$new_sizes,
+			function ( $key ) {
+				return in_array( $key, [ 'thumbnail', 'medium', 'medium_large', 'large' ] );
+			},
+			ARRAY_FILTER_USE_KEY
+		);
 	}
 
 	/**

--- a/includes/Importers/Helpers/Importer_Alterator.php
+++ b/includes/Importers/Helpers/Importer_Alterator.php
@@ -71,7 +71,7 @@ class Importer_Alterator {
 		return array_filter(
 			$new_sizes,
 			function ( $key ) {
-				return in_array( $key, [ 'thumbnail', 'medium', 'medium_large', 'large' ] );
+				return in_array( $key, array( 'thumbnail', 'medium', 'medium_large', 'large' ) );
 			},
 			ARRAY_FILTER_USE_KEY
 		);


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Previously we had a filter `add_filter( 'intermediate_image_sizes_advanced', '__return_null' );` that prevented sizes from being generated even when invoking `wp_generate_attachment_metadata()`

From my understanding, this was done to speed up the import at some time. This caused no image sizes to be generated.

Also while investigating this I found out that the size options inside Gutenberg only appear if the sizes were generated for the specific file. That's why there was a discrepancy inside the Editor.

To allow some basic sizes to be used by the design team when creating demo sites. I filtered the sizes to only default ones.


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Import Medicare from staging
2. Check that the sizes used on the About page are different than Full Size (Medium)
3. Check that for intensive imports (demo with a lot of images) the import completes without issues.

<!-- Issues that this pull request closes. -->
Closes #190.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
