### PR TITLE
feat: added changes to test lambda endpoints

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -15,6 +15,7 @@ use TIOB\Importers\Cleanup\Active_State;
  * @package templates-patterns-collection
  */
 class Admin {
+	const API = 'api.themeisle.com';
 
 	/**
 	 * Admin page slug
@@ -398,6 +399,14 @@ class Admin {
 		foreach ( $sites as $builder => $sites_for_builder ) {
 			foreach ( $sites_for_builder as $slug => $data ) {
 				$sites[ $builder ][ $slug ]['slug'] = $slug;
+				if ( defined( 'TPC_REPLACE_API_SRC' ) && TPC_REPLACE_API_SRC === true ) {
+					$api_src = defined( 'TPC_API_SRC' ) && ! empty( TPC_API_SRC ) ? TPC_API_SRC : self::API;
+
+					if ( isset( $sites[ $builder ][ $slug ]['remote_url'] ) ) {
+						$sites[ $builder ][ $slug ]['remote_url'] = str_replace( self::API, $api_src, $sites[ $builder ][ $slug ]['remote_url'] );
+					}
+					$sites[ $builder ][ $slug ]['screenshot'] = str_replace( self::API, $api_src, $sites[ $builder ][ $slug ]['screenshot'] );
+				}
 				if ( ! isset( $data['upsell'] ) || $data['upsell'] !== true ) {
 					continue;
 				}

--- a/includes/Importers/Content_Importer.php
+++ b/includes/Importers/Content_Importer.php
@@ -7,6 +7,7 @@
 
 namespace TIOB\Importers;
 
+use TIOB\Admin;
 use TIOB\Importers\Cleanup\Active_State;
 use TIOB\Importers\Helpers\Helper;
 use TIOB\Importers\Helpers\Importer_Alterator;
@@ -97,9 +98,14 @@ class Content_Importer {
 			$request_args = array(
 				'headers' => array(
 					'User-Agent' => 'WordPress/' . md5( get_site_url() ),
+					'Origin'     => get_site_url(),
 				),
 			);
 
+			if ( defined( 'TPC_REPLACE_API_SRC' ) && TPC_REPLACE_API_SRC === true ) {
+				$api_src          = defined( 'TPC_API_SRC' ) && ! empty( TPC_API_SRC ) ? TPC_API_SRC : Admin::API;
+				$content_file_url = str_replace( Admin::API, $api_src, $content_file_url );
+			}
 			$response_file = wp_remote_get( add_query_arg( 'key', apply_filters( 'product_neve_license_key', 'free' ), $content_file_url ), $request_args );
 
 			if ( is_wp_error( $response_file ) ) {


### PR DESCRIPTION
### Summary
Allows testing of lambda endpoints and will send the required `Origin` header for `.xml` files that require a license.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that the import works as before with the current API
2. Use the GIST provided [here](https://github.com/Codeinwp/themeisle-lambda-functions/pull/2) for testing with testing endpoints.

<!-- Issues that this pull request closes. -->
References: Codeinwp/demo-data-exporter#82
<!-- Should look like this: `Closes #1, #2, #3.` . -->
