### PR TITLE
fix: modal pagination

### DIFF
--- a/editor/src/scss/_pagination.scss
+++ b/editor/src/scss/_pagination.scss
@@ -3,8 +3,11 @@
 
 	.components-button {
 		margin-right: 10px;
+		margin-bottom: 8px;
 		border-radius: 2px;
 		box-shadow: none;
+		min-width: 40px;
+		justify-content: center;
 
 		&:focus {
 			box-shadow: inset 0 0 0 1px #fff, 0 0 0 1.5px #007cba;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Improved modal pagination when pagination goes on more rows than one.
Also adjusted the button size so that it looks more consistent.

![image](https://user-images.githubusercontent.com/23024731/213668201-91c3f705-46ef-45a6-9a6d-1d51786238bd.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that the pagination looks good inside the modal.
2. You can save some more templates to show the pagination on multiple rows and maybe resize the window to limit the space available for pagination so that they stack.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-cloud#59.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
