### PR TITLE
fix: license key provided when license data is malformed

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -267,7 +267,7 @@ class Admin {
 			'endpoint'            => TPC_TEMPLATES_CLOUD_ENDPOINT,
 			'params'              => array(
 				'site_url'   => get_site_url(),
-				'license_id' => License::get_license_data()->key,
+				'license_id' => License::get_license_key(),
 			),
 			'upsellNotifications' => $this->get_upsell_notifications(),
 			'isValidLicense'      => $this->has_valid_addons(),

--- a/includes/License.php
+++ b/includes/License.php
@@ -77,7 +77,7 @@ final class License {
 		// fix existing malformed data
 		$license = self::get_license_key();
 		$license_data = self::get_license_data();
-		if ( is_null( $license_data->key ) && ! empty( $license ) ) {
+		if ( ! empty( $license_data ) && is_null( $license_data->key ) && ! empty( $license ) ) {
 			$license_data->key = ! empty( $license_data->key ) ? $license_data->key : $license;
 			$this->set_license( $license, $license_data );
 		}

--- a/includes/License.php
+++ b/includes/License.php
@@ -188,6 +188,15 @@ final class License {
 	}
 
 	/**
+	 * Get the license key.
+	 *
+	 * @return string
+	 */
+	public static function get_license_key() {
+		return get_option( self::LICENSE_KEY_OPTION_KEY, 'free' );
+	}
+
+	/**
 	 * Get the license tier.
 	 *
 	 * @param int $default_tier The default tier.

--- a/includes/License.php
+++ b/includes/License.php
@@ -75,7 +75,7 @@ final class License {
 		);
 
 		// fix existing malformed data
-		$license = self::get_license_key();
+		$license      = self::get_license_key();
 		$license_data = self::get_license_data();
 		if ( ! empty( $license_data ) && is_null( $license_data->key ) && ! empty( $license ) ) {
 			$license_data->key = ! empty( $license_data->key ) ? $license_data->key : $license;

--- a/includes/License.php
+++ b/includes/License.php
@@ -73,6 +73,14 @@ final class License {
 				'default'      => '',
 			)
 		);
+
+		// fix existing malformed data
+		$license = self::get_license_key();
+		$license_data = self::get_license_data();
+		if ( is_null( $license_data->key ) && ! empty( $license ) ) {
+			$license_data->key = ! empty( $license_data->key ) ? $license_data->key : $license;
+			$this->set_license( $license, $license_data );
+		}
 	}
 
 	/**
@@ -119,7 +127,16 @@ final class License {
 
 	private function set_license( $license, $license_data ) {
 		update_option( self::LICENSE_KEY_OPTION_KEY, $license );
-		update_option( self::LICENSE_DATA_OPTIONS_KEY, $license_data );
+		$fixed_license_data = $license_data;
+		if ( isset( $license_data->license ) ) {
+			$fixed_license_data = (object) array(
+				'key'        => ! empty( $license_data->key ) ? $license_data->key : $license,
+				'valid'      => $license_data->license,
+				'expiration' => $license_data->expires,
+				'tier'       => $license_data->tier,
+			);
+		}
+		update_option( self::LICENSE_DATA_OPTIONS_KEY, $fixed_license_data );
 		set_transient( self::LICENSE_TRANSIENT_KEY, true, 12 * HOUR_IN_SECONDS );
 	}
 


### PR DESCRIPTION
### Summary
Changed how we retrieve the license key.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check the Templates from **My Library** are only the templates saved from the specific license

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-cloud#61.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
