### PR TITLE
fix: individual bulk import url generation

### DIFF
--- a/assets/src/Components/CloudLibrary/common.js
+++ b/assets/src/Components/CloudLibrary/common.js
@@ -125,7 +125,7 @@ export const fetchBulkData = async ( templates ) => {
 			cache: localStorage.getItem( 'tpcCacheBuster' ),
 			...tiobDash.params,
 		},
-	} );
+	}, {arrayFormat: 'index'} );
 
 	try {
 		const response = await apiFetch( { url, method: 'GET', parse: false } );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Passing additional arguments to `stringifyUrl` to format the array with indexes.
This solves the issue and the values are correctly passed.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check Demo Bulk Import
2. Check that all templates are imported


### 🕐 Work Time:
~1h

<!-- Issues that this pull request closes. -->
Closes #214.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
