### PR TITLE
fix: add site_url to be used for pro checks

### DIFF
--- a/assets/src/utils/rest.js
+++ b/assets/src/utils/rest.js
@@ -1,3 +1,5 @@
+import {trailingSlashIt} from "./common";
+
 export const send = ( route, data, simple = false ) => {
 	return requestData( route, simple, data );
 };
@@ -20,6 +22,12 @@ const requestData = async (
 			'Content-Type': 'application/json',
 		},
 	};
+
+	if ( tiobDash.params.site_url ) {
+		const url = new URL( route );
+		url.searchParams.append( 'site_url', encodeURIComponent( tiobDash.params.site_url ) );
+		route = url;
+	}
 
 	if ( useNonce ) {
 		options.headers[ 'x-wp-nonce' ] = tiobDash.nonce;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
For fetch requests initiated by JS will attach the `site_url` that is present on tiobDash.
This is used on license requests to validate the license and call.

This is dependent on changes from here:  https://github.com/Codeinwp/themeisle-lambda-functions/pull/6

The issue here was that my assumption was that the Origin would be the same as the site_url and could be used interchangeably. However, Origin only sends the domain of the request while we also allow for domain+path validation for the license check. So the site_url must also be forwarded especially for requests that rely on license validation.

This problem only affects a subset of licenses where the main domain might not be whitelisted, instead, a specific path of that domain is.

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Test that the import works as expected.
2. Check with PostMan that Demosites Data JSON with license accepts the arguments `&site_url=https://domain_that_needs_validation` and returns a response.

### 🕐 Worked Time:
~ 1h Code and testing
~ 1h Debugging

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-cloud#68
<!-- Should look like this: `Closes #1, #2, #3.` . -->
