### PR TITLE
Fix/refresh on gen ss

### DIFF
--- a/editor/src/extension.js
+++ b/editor/src/extension.js
@@ -10,9 +10,6 @@ import {
 	PanelBody,
 	TextControl,
 	ToggleControl,
-	Flex,
-	FlexBlock,
-	FlexItem,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -460,39 +457,16 @@ const Exporter = () => {
 					<PanelBody>
 						<h4>{ __( 'Publish Settings' ) }</h4>
 
-						<Flex
-							gap={2}
-							align="top"
-							justify="space-between"
-						>
-							<FlexBlock>
-								<TextControl
-									label={ __( 'Screenshot URL' ) }
-									value={ screenshotURL }
-									help={ __(
-										'Use `{generate_ss}` to publish this and have a screenshot automatically generated. Otherwise use the url to point to an image location for the template preview.',
-										'templates-patterns-collection'
-									) }
-									type="url"
-									onChange={ setScreenshotURL }
-								/>
-							</FlexBlock>
-							{ published && (
-								<FlexItem>
-									<Button
-										isSecondary
-										icon="image-rotate"
-										iconSize={18}
-										onClick={ refreshData }
-										disabled={ false !== isLoading }
-										className={ classnames( {
-											'is-loading': 'publishing' === isLoading,
-										} ) }
-									/>
-								</FlexItem>
+						<TextControl
+							label={ __( 'Screenshot URL' ) }
+							value={ screenshotURL }
+							help={ __(
+								'Use `{generate_ss}` to publish this and have a screenshot automatically generated. Otherwise use the url to point to an image location for the template preview.',
+								'templates-patterns-collection'
 							) }
-						</Flex>
-
+							type="url"
+							onChange={ setScreenshotURL }
+						/>
 						<TextControl
 							label={ __( 'Site Slug' ) }
 							value={ siteSlug }
@@ -504,6 +478,20 @@ const Exporter = () => {
 							onChange={ setSiteSlug }
 						/>
 						<PublishButton />
+						{ published && (
+							<Button
+								isLink
+								icon="image-rotate"
+								onClick={ refreshData }
+								disabled={ false !== isLoading }
+								className={ classnames( {
+									'is-loading': 'publishing' === isLoading,
+								} ) }
+								style={ {marginLeft: '12px', textDecoration: 'none'} }
+							>
+								{ __( 'Refresh', 'templates-patterns-collection') }
+							</Button>
+						) }
 						<Notices />
 					</PanelBody>
 				) }

--- a/elementor/src/components/export.js
+++ b/elementor/src/components/export.js
@@ -93,6 +93,34 @@ const Export = ( { updateCurrentTab } ) => {
 		updateCurrentTab( 'library' );
 	};
 
+	const refreshData = async () => {
+		setLoading( true );
+		try {
+			await getTemplate(templateID).then((results) => {
+				if (templateID === results.template_id) {
+					setScreenshotURL( results.template_thumbnail );
+					elementor.notifications.showToast( {
+						message: __('Template Data Refreshed.', 'templates-patterns-collection'),
+					} );
+					window.tiTpc.postModel.set( 'meta', {
+						_ti_tpc_template_id: templateID,
+						_ti_tpc_template_sync: templateSync,
+						_ti_tpc_screenshot_url: screenshotURL,
+						_ti_tpc_site_slug: siteSlug,
+						_ti_tpc_published: isPublished,
+					} );
+
+					window.tiTpc.postModel.save();
+				}
+			});
+		} catch ( error ) {
+			elementor.notifications.showToast( {
+				message: 'Something happened when refreshing the template data.',
+			} );
+		}
+		setLoading( false );
+	};
+
 	const publishPage = async () => {
 		setLoading( true );
 		try {
@@ -264,6 +292,25 @@ const Export = ( { updateCurrentTab } ) => {
 										? window.tiTpc.library.export.unpublish
 										: window.tiTpc.library.export.publish }
 								</Button>
+
+								{ isPublished && (
+									<Button
+										className={ classnames(
+											'elementor-button elementor-button-success',
+											{ 'elementor-button-state': isLoading }
+										) }
+										onClick={ refreshData }
+										style={ { backgroundColor: 'dimgray', marginLeft: '12px' } }
+									>
+									<span className="elementor-state-icon">
+										<i
+											className="eicon-loading eicon-animation-spin"
+											aria-hidden="true"
+										></i>
+									</span>
+										{ __( 'Refresh', 'templates-patterns-collection') }
+									</Button>
+								) }
 							</div>
 						</>
 					) }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added a refresh button for generated screenshots to update the screenshot path if the job finishes later.

**Note:** Since the jobs are handled async on the server, the image will be updated at a later date when generating screenshots. Refreshing will allow for the edited page to sync with the data from the server at a later time.

### Screenshots
Gutenberg
![image](https://user-images.githubusercontent.com/23024731/218105649-f12aaa31-0945-4c1f-a134-2bf2ceab0f99.png)

Elementor
![image](https://user-images.githubusercontent.com/23024731/218105343-7f8bf0a2-1bd9-4700-85c7-537c7e2f24e8.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. After release, validate with the Design team that it works as expected.

### 🕐 Work Time:
~ 30min

<!-- Issues that this pull request closes. -->
References #194.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
