### PR TITLE
feat: added feedback survey Codeinwp/templates-cloud#58

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,13 @@ module.exports = function (grunt) {
 						prefix: 'Version:\\s*',
 						flags: ''
 					},
+					src: [ 'templates-patterns-collection.php' ],
+				},
+				php: {
+					options: {
+						prefix: 'TIOB_VERSION\', \'',
+						flags: ''
+					},
 					src: [ 'templates-patterns-collection.php' ]
 				},
 			},

--- a/assets/src/Components/CloudLibrary/FeedbackNotice.js
+++ b/assets/src/Components/CloudLibrary/FeedbackNotice.js
@@ -73,6 +73,11 @@ const FeedbackNotice = ( { importTemplate } ) => {
             return;
         }
 
+        let feedback = feedbackDetails.trim();
+        if ( feedbackResponse !== 'other') {
+            feedback = feedbackResponse;
+        }
+
         setFeedbackStatus( 'loading' );
         try {
             fetch( 'https://api.themeisle.com/tracking/feedback', {
@@ -85,7 +90,7 @@ const FeedbackNotice = ( { importTemplate } ) => {
                 body: JSON.stringify({
                     slug: 'templates-patterns-collection',
                     version: version,
-                    feedback: feedbackDetails.trim(),
+                    feedback: feedback,
                     data: {
                         'feedback-area': 'template-patterns-collection-page-templates',
                         'feedback-option': feedbackResponse

--- a/assets/src/Components/CloudLibrary/FeedbackNotice.js
+++ b/assets/src/Components/CloudLibrary/FeedbackNotice.js
@@ -1,0 +1,250 @@
+import classnames from 'classnames';
+import { __ } from '@wordpress/i18n';
+import { Button, Flex, FlexItem, Modal, RadioControl, TextareaControl, Spinner, Icon } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { changeOption, fetchOptions } from "./common";
+
+const { version, feedback } = window.tiobDash;
+
+const collectedInfo = [
+    {
+        name: __( 'Plugin version',  'template-patterns-collection' ),
+        value: version
+    },
+    {
+        name: __( 'Feedback Response', 'otter-blocks' ),
+        value: __( 'Checked option from feedback', 'template-patterns-collection' )
+    },
+    {
+        name: __( 'Feedback Details', 'otter-blocks' ),
+        value: __( 'Text from the above text area', 'template-patterns-collection' )
+    }
+];
+
+const feedbackStatusText = {
+    error: __( 'There was a problem submitting your feedback.', 'template-patterns-collection' ),
+    emptyFeedback: __( 'Please provide a feedback before submitting the form.', 'template-patterns-collection' ),
+    submitted: __( 'Thank you for helping us improve Templates Cloud!', 'template-patterns-collection' ),
+};
+const FeedbackNotice = ( { importTemplate } ) => {
+    const [ isFeedbackOpen, setFeedbackOpen ] = useState( false );
+    const [ showInfo, setShowInfo ] = useState( false );
+    const [ feedbackResponse, setFeedbackResponse ] = useState( 'store_in_cloud' );
+    const [ feedbackDetails, setFeedbackDetails ] = useState( '' );
+    const [ feedbackStatus, setFeedbackStatus ] = useState( 'notSubmitted' );
+
+    const [ countImported, setCountImported ] = useState( feedback.count || 0 );
+    const [ isDismissed, setIsDismissed ] = useState( feedback.dismissed || false );
+    const [ hide, setHide ] = useState( false );
+
+    useEffect( () => {
+        const info = document.querySelector( '.tiob_feedback_collect.info' );
+        if ( info ) {
+            info.style.height = showInfo ? `255px` : '0';
+        }
+
+    }, [ showInfo, isFeedbackOpen ]);
+
+    const updateOptionState = () => {
+        fetchOptions().then((r) => {
+            if ( r['tiob_premade_imported'] !== undefined ) {
+                setCountImported( r['tiob_premade_imported'] );
+            }
+            if ( r['tiob_feedback_dismiss'] !== undefined ) {
+                setIsDismissed( r['tiob_feedback_dismiss'] );
+            }
+        });
+    }
+
+    useEffect( () => {
+        updateOptionState();
+    }, [ importTemplate ] );
+
+    const openModal = () => setFeedbackOpen( true );
+    const closeModal = () => setFeedbackOpen( false );
+
+    const dismissFeedback = () => {
+        changeOption( 'tiob_feedback_dismiss', true );
+    }
+
+    const submitFeedback = () => {
+        if ( feedbackResponse === 'other' && 5 >= feedbackDetails.trim().length ) {
+            setFeedbackStatus( 'emptyFeedback' );
+            return;
+        }
+
+        setFeedbackStatus( 'loading' );
+        try {
+            fetch( 'https://api.themeisle.com/tracking/feedback', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json, */*;q=0.1',
+                    'Cache-Control': 'no-cache'
+                },
+                body: JSON.stringify({
+                    slug: 'templates-patterns-collection',
+                    version: version,
+                    feedback: feedbackDetails.trim(),
+                    data: {
+                        'feedback-area': 'template-patterns-collection-page-templates',
+                        'feedback-option': feedbackResponse
+                    }
+                })
+            }).then( r => {
+                if ( ! r.ok ) {
+                    setFeedbackStatus( 'error' );
+                    closeModal();
+                    return;
+                }
+
+                setFeedbackStatus( 'submitted' );
+                closeModal();
+            })?.catch( ( error ) => {
+                console.warn( error.message );
+                setFeedbackStatus( 'error' );
+                closeModal();
+            });
+        } catch ( error ) {
+            console.warn( error.message );
+            setFeedbackStatus( 'error' );
+            closeModal();
+        }
+    };
+
+    return (
+        <>
+            { countImported >= 4 && ! isDismissed && ! hide && (
+                <Flex className="tiob-feedback-notice" justify="right">
+                    <Flex
+                        className={ classnames({
+                            'tiob-notice': true,
+                            'error': 'error' === feedbackStatus,
+                            'updated': 'submitted' === feedbackStatus,
+                        }) }
+                        justify="right">
+                        { 'submitted' === feedbackStatus && (
+                            <FlexItem>
+                                <Icon icon="saved" />
+                            </FlexItem>
+                        ) }
+                        <FlexItem>
+                            <p>{ ( ['error', 'submitted'].includes( feedbackStatus ) ) ? feedbackStatusText[feedbackStatus] : __( 'Help us improve and let us know how are you using Templates Cloud.', 'template-patterns-collection' ) }</p>
+                        </FlexItem>
+                        <FlexItem>
+                            { 'error' === feedbackStatus && (
+                                <Button
+                                    isLink
+                                    className="error"
+                                    onClick={openModal}
+                                >
+                                    { __( 'Try again', 'template-patterns-collection' ) }
+                                </Button>
+                            ) }
+                            { ! ['error', 'submitted'].includes( feedbackStatus ) && (
+                                <Button
+                                    isPrimary
+                                    onClick={ openModal }
+                                >
+                                    { __( 'Share feedback', 'template-patterns-collection' ) }
+                                </Button>
+                            ) }
+                        </FlexItem>
+                        <FlexItem>
+                            <Button
+                                isTertiary
+                                icon="no-alt"
+                                iconSize={20}
+                                onClick={ () => {
+                                    setHide( true )
+                                    if ( feedbackStatus !== 'error' ) {
+                                        dismissFeedback();
+                                    }
+                                } }
+                            />
+                        </FlexItem>
+                    </Flex>
+                </Flex>
+            ) }
+            { isFeedbackOpen && (
+                <Modal
+                    className="tiob_feedback_modal"
+                    title={ __( 'How are you using Templates Cloud?', 'template-patterns-collection' ) }
+                    onRequestClose={ closeModal }
+                >
+                    <RadioControl
+                        className="feedback_options"
+                        selected={ feedbackResponse }
+                        options={ [
+                            { label: __( 'To store my templates in the cloud', 'template-patterns-collection' ), value: 'store_in_cloud' },
+                            { label: __( 'To share templates with the clients', 'template-patterns-collection' ), value: 'share_with_clients' },
+                            { label: __( 'Other', 'template-patterns-collection' ), value: 'other' },
+                        ] }
+                        onChange={ ( value ) => setFeedbackResponse( value ) }
+                    />
+                    { feedbackResponse === 'other' && (
+                        <TextareaControl
+                            className={ classnames({
+                                'feedback_details': true,
+                                'invalid': 'emptyFeedback' === feedbackStatus,
+                            }) }
+                            placeholder={ __( 'Tell us more ...', 'template-patterns-collection' ) }
+                            value={ feedbackDetails }
+                            help={ feedbackStatusText[feedbackStatus] || false }
+                            rows={7}
+                            cols={50}
+                            onChange={ value => {
+                                setFeedbackDetails( value );
+                                if ( 5 < value.trim().length ) {
+                                    setFeedbackStatus( 'notSubmitted' );
+                                }
+                            } }
+                        />
+                    ) }
+                    <div className="tiob_feedback_collect info">
+                        <div className="wrapper">
+                            <p>{ __( 'We value privacy, that\'s why no domain name, email address or IP addresses are collected after you submit the survey. Below is a detailed view of all data that Themeisle will receive if you fill in this survey.', 'template-patterns-collection' ) }</p>
+                            { collectedInfo.map( ( row, index ) => {
+                                return (
+                                    <div className="info-row" key={ index }>
+                                        <p><b>{ row.name }</b></p>
+                                        <p>{ row.value }</p>
+                                    </div>
+                                );
+                            }) }
+                        </div>
+                    </div>
+                    <Flex
+                        direction="column"
+                        align="left"
+                        justify="start"
+                        style={ { height: 'auto' } }
+                    >
+                        <FlexItem>
+                            <Button
+                                isPrimary
+                                onClick={ submitFeedback }
+                                disabled={ 'loading' === feedbackStatus }
+                            >
+                                { 'loading' === feedbackStatus ? <Spinner /> : __( 'Submit feedback', 'template-patterns-collection' ) }
+                            </Button>
+                        </FlexItem>
+                        <FlexItem>
+                            <Button
+                                className="toggle-info"
+                                aria-expanded={ showInfo }
+                                variant="link"
+                                isLink
+                                onClick={() => setShowInfo( ! showInfo )}
+                            >
+                                { __( 'What info do we collect?', 'template-patterns-collection' ) }
+                            </Button>
+                        </FlexItem>
+                    </Flex>
+                </Modal>
+            ) }
+        </>
+    );
+};
+
+export default FeedbackNotice;

--- a/assets/src/Components/CloudLibrary/FeedbackNotice.js
+++ b/assets/src/Components/CloudLibrary/FeedbackNotice.js
@@ -99,6 +99,7 @@ const FeedbackNotice = ( { importTemplate } ) => {
                 }
 
                 setFeedbackStatus( 'submitted' );
+                dismissFeedback();
                 closeModal();
             })?.catch( ( error ) => {
                 console.warn( error.message );

--- a/assets/src/Components/CloudLibrary/ImportTemplatesModal.js
+++ b/assets/src/Components/CloudLibrary/ImportTemplatesModal.js
@@ -31,10 +31,6 @@ const ImportTemplatesModal = ( {
 
 	const isSingle = templatesData.length === 1;
 
-	console.log( themeData );
-	console.log( isUserTemplate );
-	console.log( generalTemplates );
-
 	useEffect( () => {
 		if ( isUserTemplate && isSingle ) {
 			getUserTemplateData( templatesData[ 0 ].template_id ).then(

--- a/assets/src/Components/CloudLibrary/Library.js
+++ b/assets/src/Components/CloudLibrary/Library.js
@@ -16,6 +16,7 @@ import PreviewFrame from './PreviewFrame';
 import ImportTemplatesModal from './ImportTemplatesModal';
 import Logo from '../Icon';
 import { LicensePanelContext } from '../LicensePanelContext';
+import FeedbackNotice from "./FeedbackNotice";
 
 const Library = ( {
 	isGeneral,
@@ -387,6 +388,7 @@ const Library = ( {
 							</span>
 						</a>
 					) ) }
+					<FeedbackNotice importTemplate={templateModal} />
 				</div>
 				<Filters
 					currentTab={ currentTab }

--- a/assets/src/Components/CloudLibrary/common.js
+++ b/assets/src/Components/CloudLibrary/common.js
@@ -3,6 +3,31 @@ import apiFetch from '@wordpress/api-fetch';
 
 import { stringifyUrl } from 'query-string';
 import { v4 as uuidv4 } from 'uuid';
+import { models, loadPromise } from '@wordpress/api';
+
+export const changeOption = ( option, value ) => {
+	const model = new models.Settings( {
+		[ option ]: value,
+	} );
+
+	return new Promise( ( resolve ) => {
+		model.save().then( ( r ) => {
+			if ( ! r || ! r[ option ] === value ) {
+				resolve( { success: false } );
+			}
+
+			resolve( { success: true } );
+		} );
+	} );
+};
+
+export const fetchOptions = () => {
+	let settings;
+	return loadPromise.then(() => {
+		settings = new models.Settings();
+		return settings.fetch();
+	});
+};
 
 export const fetchLibrary = async (
 	premade = false,

--- a/assets/src/scss/_feedback.scss
+++ b/assets/src/scss/_feedback.scss
@@ -1,0 +1,87 @@
+.tiob-feedback-notice {
+  padding: 8px 4px;
+  .tiob-notice {
+    height: 46px;
+    max-width: 600px;
+    width: auto;
+    background-color: #fff;
+    padding: 0 8px;
+    border-radius: 4px;
+    transition: width 0.8s;
+    margin: 0;
+    &:not(.error):not(.update) {
+      border: 1px solid transparent;
+    }
+
+    .dashicons-saved {
+      color: #00a32a;
+    }
+
+    button.is-tertiary {
+      color: #1e1e1e;
+      &:hover {
+        color: var(--wp-admin-theme-color);
+        box-shadow: none;
+      }
+    }
+
+    button.error {
+      color: red;
+      &:hover {
+        color: #1e1e1e;
+      }
+    }
+  }
+}
+
+.tiob_feedback_modal {
+  max-width: 500px;
+  border-radius: 4px;
+  .components-modal__header {
+    background-color: var(--wp-admin-theme-color);
+    h1 {
+      color: #fff;
+    }
+    .components-button {
+      color: #fff;
+      &:hover {
+        color: #1e1e1e;
+      }
+    }
+  }
+
+  .feedback_options {
+    margin-top: 16px;
+    .components-flex.components-h-stack  {
+      gap: calc(8px);
+    }
+  }
+
+  .feedback_details {
+    margin-top: 16px;
+    &.invalid textarea {
+      border-color: red;
+    }
+    &.invalid p {
+      color: red;
+    }
+  }
+
+  .tiob_feedback_collect.info {
+    overflow: hidden;
+    transition: height .5s;
+    margin-top: 16px;
+
+    .info-row {
+      padding: 0 12px;
+      background-color: #efefef;
+      display: flex;
+      justify-content: space-between;
+      border-bottom: 1px solid #9e9e9e;
+
+      &:nth-child( odd ) {
+        background-color: #fff;
+      }
+    }
+  }
+}

--- a/assets/src/scss/_feedback.scss
+++ b/assets/src/scss/_feedback.scss
@@ -9,7 +9,7 @@
     border-radius: 4px;
     transition: width 0.8s;
     margin: 0;
-    &:not(.error):not(.update) {
+    &:not(.error):not(.updated) {
       border: 1px solid transparent;
     }
 

--- a/assets/src/style.scss
+++ b/assets/src/style.scss
@@ -16,6 +16,7 @@
 @import "scss/notification";
 @import "scss/custom-tooltip";
 @import "scss/license";
+@import "scss/feedback";
 
 @import "scss/media-queries";
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -18,7 +18,7 @@ class Admin {
 	const API = 'api.themeisle.com';
 
 	const IMPORTED_TEMPLATES_COUNT_OPT = 'tiob_premade_imported';
-	const FEEDBACK_DISMISSED_OPT = 'tiob_feedback_dismiss';
+	const FEEDBACK_DISMISSED_OPT       = 'tiob_feedback_dismiss';
 
 	/**
 	 * Admin page slug
@@ -76,20 +76,20 @@ class Admin {
 		register_setting(
 			'tiob_feedback',
 			self::IMPORTED_TEMPLATES_COUNT_OPT,
-			[
+			array(
 				'type'         => 'integer',
 				'show_in_rest' => true,
 				'default'      => 0,
-			]
+			)
 		);
 		register_setting(
 			'tiob_feedback',
 			self::FEEDBACK_DISMISSED_OPT,
-			[
+			array(
 				'type'         => 'boolean',
 				'show_in_rest' => true,
 				'default'      => false,
-			]
+			)
 		);
 	}
 
@@ -315,10 +315,10 @@ class Admin {
 				'skipStatus' => $this->get_skip_subscribe_status() ? 'yes' : 'no',
 				'email'      => ( ! empty( $user ) ) ? $user->user_email : '',
 			),
-			'feedback' => [
-				'count' => get_option( self::IMPORTED_TEMPLATES_COUNT_OPT, 0 ),
+			'feedback'            => array(
+				'count'     => get_option( self::IMPORTED_TEMPLATES_COUNT_OPT, 0 ),
 				'dismissed' => get_option( self::FEEDBACK_DISMISSED_OPT, false ),
-			],
+			),
 		);
 	}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -17,6 +17,9 @@ use TIOB\Importers\Cleanup\Active_State;
 class Admin {
 	const API = 'api.themeisle.com';
 
+	const IMPORTED_TEMPLATES_COUNT_OPT = 'tiob_premade_imported';
+	const FEEDBACK_DISMISSED_OPT = 'tiob_feedback_dismiss';
+
 	/**
 	 * Admin page slug
 	 *
@@ -60,6 +63,34 @@ class Admin {
 
 		add_action( 'wp_ajax_skip_subscribe', array( $this, 'skip_subscribe' ) );
 		add_action( 'wp_ajax_nopriv_skip_subscribe', array( $this, 'skip_subscribe' ) );
+
+		$this->register_feedback_settings();
+	}
+
+	/**
+	 * Register feedback settings.
+	 *
+	 * @return void
+	 */
+	private function register_feedback_settings() {
+		register_setting(
+			'tiob_feedback',
+			self::IMPORTED_TEMPLATES_COUNT_OPT,
+			[
+				'type'         => 'integer',
+				'show_in_rest' => true,
+				'default'      => 0,
+			]
+		);
+		register_setting(
+			'tiob_feedback',
+			self::FEEDBACK_DISMISSED_OPT,
+			[
+				'type'         => 'boolean',
+				'show_in_rest' => true,
+				'default'      => false,
+			]
+		);
 	}
 
 	/**
@@ -254,6 +285,7 @@ class Admin {
 		}
 
 		return array(
+			'version'             => TIOB_VERSION,
 			'nonce'               => wp_create_nonce( 'wp_rest' ),
 			'assets'              => TIOB_URL . '/assets/',
 			'upgradeURL'          => $upgrade_url,
@@ -283,6 +315,10 @@ class Admin {
 				'skipStatus' => $this->get_skip_subscribe_status() ? 'yes' : 'no',
 				'email'      => ( ! empty( $user ) ) ? $user->user_email : '',
 			),
+			'feedback' => [
+				'count' => get_option( self::IMPORTED_TEMPLATES_COUNT_OPT, 0 ),
+				'dismissed' => get_option( self::FEEDBACK_DISMISSED_OPT, false ),
+			],
 		);
 	}
 

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -315,6 +315,11 @@ class Rest_Server {
 				),
 			);
 		}
+		
+		$count = get_option( Admin::IMPORTED_TEMPLATES_COUNT_OPT, 0 );
+		update_option( Admin::IMPORTED_TEMPLATES_COUNT_OPT, intval( $count ) + sizeof( $imported ) );
+		
+		error_log( var_export( get_option( Admin::IMPORTED_TEMPLATES_COUNT_OPT, 0 ), true ) );
 
 		return new WP_REST_Response(
 			array(

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -315,10 +315,10 @@ class Rest_Server {
 				),
 			);
 		}
-		
+
 		$count = get_option( Admin::IMPORTED_TEMPLATES_COUNT_OPT, 0 );
 		update_option( Admin::IMPORTED_TEMPLATES_COUNT_OPT, intval( $count ) + sizeof( $imported ) );
-		
+
 		error_log( var_export( get_option( Admin::IMPORTED_TEMPLATES_COUNT_OPT, 0 ), true ) );
 
 		return new WP_REST_Response(

--- a/templates-patterns-collection.php
+++ b/templates-patterns-collection.php
@@ -55,6 +55,7 @@ function ti_tpc_load_textdomain() {
 	load_plugin_textdomain( 'templates-patterns-collection', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 }
 
+define( 'TIOB_VERSION', '1.1.34' );
 define( 'TIOB_URL', plugin_dir_url( __FILE__ ) );
 define( 'TIOB_PATH', dirname( __FILE__ ) . '/' );
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added feedback survey after 4 imported templates it will be displayed on the Templates Page.


### Screenshots:
![image](https://user-images.githubusercontent.com/23024731/219415554-61500055-13c3-46cf-b884-a829a4b3cacb.png)

![image](https://user-images.githubusercontent.com/23024731/219415646-b1b1fd4b-b4a0-46c1-aae7-534e0a07d87c.png)

![image](https://user-images.githubusercontent.com/23024731/219415705-cc5813c0-fee6-4266-b926-e384ce5e7452.png)

![image](https://user-images.githubusercontent.com/23024731/219415772-f8e6c48f-1b80-412e-ae19-358fa4742e8b.png)

Error on submit:
![image](https://user-images.githubusercontent.com/23024731/219415914-c6ef437e-948c-445a-8aed-f38882dfcba5.png)

Submit successfully!
![image](https://user-images.githubusercontent.com/23024731/219416324-d580b704-291b-46b7-b164-b597733ed4f3.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Import 4 Page Templates
2. After the 4th import the feedback notice should be presented.
3. Check that the feedback form is submitted
4. Check that on dismiss it will not be presented again

`wp option set tiob_premade_imported 4` and `wp option set tiob_feedback_dismiss false` can be used to set the options to various conditions.

### 🕐 Work Time:
~ 4h
~ 10min ( QA fix )

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-cloud#58.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
