### PR TITLE
feat: allow neve custom layouts to be saved and imported Codeinwp/nev…

### DIFF
--- a/editor/src/edit.js
+++ b/editor/src/edit.js
@@ -126,10 +126,11 @@ const Edit = ( {
 	const importBlocks = ( content, metaFields = [] ) => {
 		updateLibrary( [] );
 		updateTemplates( [] );
+		const { allowed_post } = window.tiTpc;
 
 		if (
 			0 < Object.keys( tryParseJSON( metaFields ) || {} ).length &&
-			[ 'post', 'page' ].includes( type )
+			allowed_post.includes( type )
 		) {
 			const fields = JSON.parse( metaFields );
 			const meta = {

--- a/editor/src/extension.js
+++ b/editor/src/extension.js
@@ -255,12 +255,17 @@ const Exporter = () => {
 			return;
 		}
 
+		let meta = tiTpc.params.meta;
+		// For Custom Layouts attach additional meta to check on import.
+		if ( type === 'neve_custom_layouts' ) {
+			meta = { ...tiTpc.params.meta, postType: type };
+		}
 		if ( ! doesExist ) {
 			url = stringifyUrl( {
 				url: window.tiTpc.endpoint + 'templates',
 				query: {
 					...omit( tiTpc.params, 'meta' ),
-					meta: JSON.stringify( tiTpc.params.meta ),
+					meta: JSON.stringify( meta ),
 					template_name: postTitle,
 					template_type: 'gutenberg',
 					template_site_slug: _ti_tpc_site_slug || '',
@@ -273,7 +278,7 @@ const Exporter = () => {
 				url: window.tiTpc.endpoint + 'templates/' + templateID,
 				query: {
 					...omit( tiTpc.params, 'meta' ),
-					meta: JSON.stringify( tiTpc.params.meta ),
+					meta: JSON.stringify( meta ),
 					template_name: postTitle,
 					link,
 				},
@@ -397,6 +402,8 @@ const Exporter = () => {
 			post = new wp.api.models.Post( { id: postId } );
 		} else if ( type === 'page' ) {
 			post = new wp.api.models.Page( { id: postId } );
+		} else if ( type === 'neve_custom_layouts' ) {
+			post = new wp.api.models.Neve_custom_layouts( { id: postId } );
 		}
 
 		post.set( 'meta', {
@@ -409,7 +416,8 @@ const Exporter = () => {
 		return post.save();
 	};
 
-	if ( ! [ 'post', 'page' ].includes( type ) ) {
+	const { allowed_post } = window.tiTpc;
+	if ( ! allowed_post.includes( type ) ) {
 		return null;
 	}
 

--- a/includes/Editor.php
+++ b/includes/Editor.php
@@ -16,6 +16,8 @@ use TIOB\Main;
  */
 class Editor {
 
+	const ALLOWED_POST_TYPES = array( 'post', 'page', 'neve_custom_layouts' );
+
 	/**
 	 * Assets Handle.
 	 *
@@ -71,6 +73,7 @@ class Editor {
 					),
 					'metaKeys'     => apply_filters( 'ti_tpc_template_meta', array(), $post_id = get_the_ID(), $type = 'gutenberg' ),
 					'canPredefine' => apply_filters( 'ti_tpc_can_predefine', false ),
+					'allowed_post' => self::ALLOWED_POST_TYPES,
 				)
 			)
 		);

--- a/includes/Editor.php
+++ b/includes/Editor.php
@@ -26,6 +26,15 @@ class Editor {
 	private $handle = 'ti-tpc-block';
 
 	/**
+	 * Get allowed post types.
+	 *
+	 * @return array
+	 */
+	public static function get_allowed_post_types() {
+		return apply_filters( 'ti_tpc_allowed_post_types', self::ALLOWED_POST_TYPES );
+	}
+
+	/**
 	 * Initialize the Admin.
 	 */
 	public function init() {
@@ -73,7 +82,7 @@ class Editor {
 					),
 					'metaKeys'     => apply_filters( 'ti_tpc_template_meta', array(), $post_id = get_the_ID(), $type = 'gutenberg' ),
 					'canPredefine' => apply_filters( 'ti_tpc_can_predefine', false ),
-					'allowed_post' => self::ALLOWED_POST_TYPES,
+					'allowed_post' => self::get_allowed_post_types(),
 				)
 			)
 		);

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -353,7 +353,7 @@ class Rest_Server {
 
 			if (
 				isset( $meta['postType'] ) &&
-				in_array( $meta['postType'], Editor::ALLOWED_POST_TYPES, true ) &&
+				in_array( $meta['postType'], Editor::get_allowed_post_types(), true ) &&
 				post_type_exists( $meta['postType'] )
 			) {
 				$post_type = $meta['postType'];

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -351,7 +351,11 @@ class Rest_Server {
 				$page_template = $meta['_wp_page_template'];
 			}
 
-			if ( isset( $meta['postType'] ) && in_array( $meta['postType'], Editor::ALLOWED_POST_TYPES, true ) ) {
+			if (
+				isset( $meta['postType'] ) &&
+				in_array( $meta['postType'], Editor::ALLOWED_POST_TYPES, true ) &&
+				post_type_exists( $meta['postType'] )
+			) {
 				$post_type = $meta['postType'];
 			}
 		}

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -339,6 +339,7 @@ class Rest_Server {
 		);
 
 		$page_template = '';
+		$post_type     = 'page';
 
 		if ( 'gutenberg' !== $template['template_type'] ) {
 			$page_template = 'page-templates/template-pagebuilder-full-width.php';
@@ -348,6 +349,10 @@ class Rest_Server {
 			$meta = json_decode( $template['meta'], true );
 			if ( isset( $meta['_wp_page_template'] ) ) {
 				$page_template = $meta['_wp_page_template'];
+			}
+
+			if ( isset( $meta['postType'] ) && in_array( $meta['postType'], Editor::ALLOWED_POST_TYPES, true ) ) {
+				$post_type = $meta['postType'];
 			}
 		}
 
@@ -404,7 +409,7 @@ class Rest_Server {
 				'post_title'    => wp_strip_all_tags( $template['template_name'] ),
 				'post_content'  => wp_kses_post( $template['content'] ),
 				'post_status'   => 'publish',
-				'post_type'     => 'page',
+				'post_type'     => $post_type,
 				'page_template' => $page_template,
 				'meta_input'    => isset( $template['meta'] ) ? json_decode( $template['meta'], true ) : array(),
 			)


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Allow saving of Custom Layouts (`neve_custom_layouts` post type).
Minor code optimizations.
`neve_custom_layouts` to be saved to Templates Cloud and can be Imported as Custom Layouts or as the content inside any other post type.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Create a Neve Custom Layout, and check that it can be saved to Templates Cloud
2. Check that if imported from My Library it will create a new Custom Layout post type.
3. Check that it can be imported just the content from any Gutenberg post.

### 🕐 Work Time:
~ 2h ( including testing )

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2346.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
