### PR TITLE
fix: pin node version to 16.x to avoid issues with legacy ssl on build

### DIFF
--- a/.github/workflows/build-dev-artifact.yml
+++ b/.github/workflows/build-dev-artifact.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Check out source files
         uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/gallium # 16.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/gallium # 16.x
       - name: Build
         run: |
           yarn install --frozen-lockfile

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/gallium # 16.x
       - name: Build
         run: |
           yarn install --frozen-lockfile

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,3 @@ jobs:
           working-directory: ./e2e-tests
           env: host=localhost,port=8080
           browser: chrome
-          parallel: true
-          headless: true
-          group: e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,4 +38,3 @@ jobs:
           parallel: true
           headless: true
           group: e2e
-          record: true

--- a/e2e-tests/cypress/integration/dashboard.spec.ts
+++ b/e2e-tests/cypress/integration/dashboard.spec.ts
@@ -141,10 +141,10 @@ describe('Importer Works', function () {
       'https://api.themeisle.com/sites/web-agency-gb/wp-json/ti-demo-data/data?license=*',
     ).as('getModalData');
 
-    cy.intercept('POST', 'install_plugins').as('installPlugins');
-    cy.intercept('POST', 'import_content').as('importContent');
-    cy.intercept('POST', 'import_theme_mods').as('importCustomizer');
-    cy.intercept('POST', 'import_widgets').as('importWidgets');
+    cy.intercept('POST', '**install_plugins*').as('installPlugins');
+    cy.intercept('POST', '**import_content*').as('importContent');
+    cy.intercept('POST', '**import_theme_mods*').as('importCustomizer');
+    cy.intercept('POST', '**import_widgets*').as('importWidgets');
 
     cy.get('.starter-site-card').first().as('firstCard');
     cy.get('@firstCard').trigger('mouseover');
@@ -169,6 +169,7 @@ describe('Importer Works', function () {
     cy.get('.ob-import-modal').wait(1000).find('button').contains('Import entire site').click();
 
     cy.wait('@installPlugins', { timeout: 20000 }).then((req) => {
+      console.log( req.response.statusCode );
       expect(req.response.statusCode).to.equal(200);
     });
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Pinned Node version to 16.* (lts/gallium) on newer version SSL error is thrown on the build.
Another possible fix could be to set `set NODE_OPTIONS='--openssl-legacy-provider'` prior to invoking the build

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Github actions for the build should pass without error.

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
