### PR TITLE
fix: solve admin paths

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -253,11 +253,11 @@ class Admin {
 
 		$dependencies = ( include TIOB_PATH . 'assets/build/app.asset.php' );
 
-		wp_register_style( 'tiob', TIOB_URL . '/assets/build/style-app.css', array( 'wp-components' ), $dependencies['version'] );
+		wp_register_style( 'tiob', TIOB_URL . 'assets/build/style-app.css', array( 'wp-components' ), $dependencies['version'] );
 		wp_style_add_data( 'tiob', 'rtl', 'replace' );
 		wp_enqueue_style( 'tiob' );
 
-		wp_register_script( 'tiob', TIOB_URL . '/assets/build/app.js', array_merge( $dependencies['dependencies'], array( 'updates' ) ), $dependencies['version'], true );
+		wp_register_script( 'tiob', TIOB_URL . 'assets/build/app.js', array_merge( $dependencies['dependencies'], array( 'updates' ) ), $dependencies['version'], true );
 		wp_localize_script( 'tiob', 'tiobDash', apply_filters( 'neve_dashboard_page_data', $this->get_localization() ) );
 		wp_enqueue_script( 'tiob' );
 	}
@@ -287,7 +287,7 @@ class Admin {
 		return array(
 			'version'             => TIOB_VERSION,
 			'nonce'               => wp_create_nonce( 'wp_rest' ),
-			'assets'              => TIOB_URL . '/assets/',
+			'assets'              => TIOB_URL . 'assets/',
 			'upgradeURL'          => $upgrade_url,
 			'upgradeURLTpc'       => $upgrade_url_tpc,
 			'strings'             => array(
@@ -519,8 +519,8 @@ class Admin {
 
 		$options = array(
 			'theme_name'          => ! empty( $data[ $old_theme ]['theme_name'] ) ? esc_html( $data[ $old_theme ]['theme_name'] ) : '',
-			'screenshot'          => TIOB_URL . '/migration/' . $folder_name . '/' . $data[ $old_theme ]['template'] . '.png',
-			'template'            => TIOB_PATH . '/migration/' . $folder_name . '/' . $data[ $old_theme ]['template'] . '.json',
+			'screenshot'          => TIOB_URL . 'migration/' . $folder_name . '/' . $data[ $old_theme ]['template'] . '.png',
+			'template'            => TIOB_PATH . 'migration/' . $folder_name . '/' . $data[ $old_theme ]['template'] . '.json',
 			'template_name'       => $data[ $old_theme ]['template'],
 			'heading'             => $data[ $old_theme ]['heading'],
 			'description'         => $data[ $old_theme ]['description'],


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Updated the admin URL paths to have the same format. Right now they have a double `//` but it does not affect the loading of the assets.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that the plugin loads as before.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-cloud#73.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
