### PR TITLE
feat: when clonning posts clear template specific metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 languages/*.pot
 **/build/*
 **/.DS_Store
+.phpunit.result.cache

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -81,15 +81,15 @@ class Admin {
 
 		// Check if the template ID is used on any other posts or pages
 		// exclude the current post from the query
-		$args = array(
-			'post_type' => Editor::get_allowed_post_types(),
-			'meta_key' => '_ti_tpc_template_id',
-			'meta_value' => $template_id,
-			'post__not_in' => array( $post_id ),
+		$args         = array(
+			'post_type'      => Editor::get_allowed_post_types(),
+			'meta_key'       => '_ti_tpc_template_id',
+			'meta_value'     => $template_id,
+			'post__not_in'   => array( $post_id ),
 			'posts_per_page' => 1,
-			'fields' => 'ids',
+			'fields'         => 'ids',
 		);
-		$query = new \WP_Query( $args );
+		$query        = new \WP_Query( $args );
 		$duplicate_id = $query->get_posts();
 
 		if ( ! empty( $duplicate_id ) ) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -8,6 +8,7 @@
 namespace TIOB;
 
 use TIOB\Importers\Cleanup\Active_State;
+use function Sodium\add;
 
 /**
  * Class Admin
@@ -66,23 +67,85 @@ class Admin {
 
 		$this->register_feedback_settings();
 
-		add_action( 'save_post', array( $this, 'check_unique_template_id_on_save' ) );
+		$this->register_prevent_clone_hooks();
+	}
+
+	/**
+	 * Register hooks to prevent meta cloning for the templates.
+	 * This is needed because the template id is unique, and we don't want to clone it.
+	 * @return void
+	 */
+	public function register_prevent_clone_hooks() {
+		$allowed_post_types = Editor::get_allowed_post_types();
+		if ( empty( $allowed_post_types ) ) {
+			return;
+		}
+		foreach ( $allowed_post_types as $post_type ) {
+			add_filter(
+				'update_' . $post_type . '_metadata',
+				function ( $value, $post_id, $meta_key, $meta_value, $prev_value ) use ( $post_type ) {
+					if ( $this->check_unique_template_id_on_meta_change( $post_id, $meta_key, $post_type, $meta_value ) ) {
+						return true;
+					}
+					return $value;
+				},
+				10,
+				5
+			);
+			add_filter(
+				'add_' . $post_type . '_metadata',
+				function ( $value, $post_id, $meta_key, $meta_value, $unique ) use ( $post_type ) {
+					if ( $this->check_unique_template_id_on_meta_change( $post_id, $meta_key, $post_type, $meta_value ) ) {
+						return true;
+					}
+					return $value;
+				},
+				10,
+				5
+			);
+		}
 	}
 
 	/**
 	 * Check that the meta value is unique for the allowed post types that support Templates Cloud.
 	 *
 	 * @param int $post_id The post ID.
+	 * @param string $meta_key The meta key.
+	 * @param string $meta_type The meta type. The post type ( post, page, neve_custom_layouts etc. ).
+	 * @param string $meta_value The meta value.
 	 *
-	 * @return void
+	 * @return bool
 	 */
-	public function check_unique_template_id_on_save( $post_id ) {
+	public function check_unique_template_id_on_meta_change( $post_id, $meta_key, $meta_type, $meta_value ) {
+		// Skip check if the meta key is not one of the allowed ones.
+		if ( ! in_array(
+			$meta_key,
+			array(
+				'_ti_tpc_template_sync',
+				'_ti_tpc_template_id',
+				'_ti_tpc_screenshot_url',
+				'_ti_tpc_site_slug',
+				'_ti_tpc_published',
+			),
+			true
+		)
+		) {
+			return false;
+		}
+
+		if ( empty( $meta_value ) ) {
+			return false;
+		}
+
 		$template_id = get_post_meta( $post_id, '_ti_tpc_template_id', true );
+		if ( empty( $template_id ) && $meta_key === '_ti_tpc_template_id' ) {
+			$template_id = $meta_value;
+		}
 
 		// Check if the template ID is used on any other posts or pages
 		// exclude the current post from the query
 		$args         = array(
-			'post_type'      => Editor::get_allowed_post_types(),
+			'post_type'      => $meta_type,
 			'meta_key'       => '_ti_tpc_template_id',
 			'meta_value'     => $template_id,
 			'post__not_in'   => array( $post_id ),
@@ -93,13 +156,10 @@ class Admin {
 		$duplicate_id = $query->get_posts();
 
 		if ( ! empty( $duplicate_id ) ) {
-			// Clear the metadata for the current post if the template ID is already used
-			update_post_meta( $post_id, '_ti_tpc_template_sync', false );
-			update_post_meta( $post_id, '_ti_tpc_template_id', '' );
-			update_post_meta( $post_id, '_ti_tpc_screenshot_url', '' );
-			update_post_meta( $post_id, '_ti_tpc_site_slug', '' );
-			update_post_meta( $post_id, '_ti_tpc_published', false );
+			// The template ID is already used on another post
+			return true;
 		}
+		return false;
 	}
 
 	/**

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -69,6 +69,13 @@ class Admin {
 		add_action( 'save_post', array( $this, 'check_unique_template_id_on_save' ) );
 	}
 
+	/**
+	 * Check that the meta value is unique for the allowed post types that support Templates Cloud.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return void
+	 */
 	public function check_unique_template_id_on_save( $post_id ) {
 		$template_id = get_post_meta( $post_id, '_ti_tpc_template_id', true );
 

--- a/tests/post-clone-test.php
+++ b/tests/post-clone-test.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Post clone tests.
+ *
+ * @author Bogdan Preda <bogdan.preda@themeisle.com>
+ * @package templates-patterns-collection
+ */
+
+use TIOB\Admin;
+
+/**
+ * Class Post_Clone_Test
+ */
+class Post_Clone_Test extends WP_UnitTestCase {
+
+	private $post_id;
+
+	/**
+	 * Create a post with _ti_tpc_template_id meta.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$admin = new Admin();
+		add_action( 'save_post', array( $admin, 'check_unique_template_id_on_save' ) );
+
+		$this->post_id = $this->factory->post->create(
+			array(
+				'post_title' => 'Test Source Post',
+				'post_type'  => 'post',
+			)
+		);
+		update_post_meta( $this->post_id, '_ti_tpc_template_id', 'tpc_template_test_ID' );
+		update_post_meta( $this->post_id, '_ti_tpc_template_sync', true );
+		update_post_meta( $this->post_id, '_ti_tpc_published', true );
+	}
+
+	/**
+	 * Clone a post and its meta.
+	 *
+	 * @return int
+	 */
+	private function clone_post_and_meta() {
+		$post = get_post( $this->post_id );
+		$new_post_id = wp_insert_post(
+			array(
+				'post_title'   => $post->post_title,
+				'post_content' => $post->post_content,
+				'post_status'  => 'publish',
+				'post_type'    => $post->post_type,
+			)
+		);
+		$meta_keys = get_post_custom_keys( $this->post_id );
+		foreach ( $meta_keys as $meta_key ) {
+			$meta_values = get_post_custom_values( $meta_key, $this->post_id );
+			foreach ( $meta_values as $meta_value ) {
+				$meta_value = maybe_unserialize( $meta_value );
+				add_post_meta( $new_post_id, $meta_key, $meta_value );
+			}
+		}
+		return $new_post_id;
+	}
+
+	/**
+	 * Test that the post has the meta defined and if cloned the meta is not the same.
+	 */
+	final public function test_post_meta_and_clone() {
+		$this->assertTrue( get_post_meta( $this->post_id, '_ti_tpc_template_id', true ) === 'tpc_template_test_ID' );
+		$this->assertTrue( ! empty( get_post_meta( $this->post_id, '_ti_tpc_template_sync', true ) ) );
+		$this->assertTrue( ! empty( get_post_meta( $this->post_id, '_ti_tpc_published', true ) ) );
+
+		$clone_post_id = $this->clone_post_and_meta();
+
+		// assert that the new cloned post does not have the same meta as the original.
+		var_dump( get_post_meta( $clone_post_id, '_ti_tpc_template_id', true ) );
+		$this->assertTrue( $clone_post_id !== $this->post_id );
+		$this->assertTrue( get_post_meta( $clone_post_id, '_ti_tpc_template_id', true ) !== 'tpc_template_test_ID' );
+		$this->assertTrue( empty( get_post_meta( $clone_post_id, '_ti_tpc_template_sync', true ) ) );
+		$this->assertTrue( empty( get_post_meta( $clone_post_id, '_ti_tpc_published', true ) ) );
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
- Hooked into `update_{post_type}_metadata` and `add_{post_type}_metadat`  to clear meta values used for Templates Cloud if the `_ti_tpc_template_id` value is already used.
- Added PHPUnit test to check that on cloning the meta is stripped if it already exists. Checks that only if a template_id is already present the meta is not added.

### Notes for QA and for Reviewers:
This will only work when cloning posts or copying posts that leverage native WP functions like `update_meta()` or `add_meta()` for custom queries or direct DB inserts this can not prevent meta duplication.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Create a Template ( Post or Page ) and save it to Templates Cloud (My Library) with
2. Use a cloning tool to clone the ( Post or Page ) Eg. [Clone Posts](https://wordpress.org/plugins/clone-posts/)
3. Check that when editing the Clone and saving it to Templates Cloud the changes are not updated for the source of the clone.
4. Check the same applies when using template sync.

<!-- Issues that this pull request closes. -->
Closes #198.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
