### PR TITLE
chore: exclude membership page from being hashed to preserve link

### DIFF
--- a/includes/Importers/Helpers/Helper.php
+++ b/includes/Importers/Helpers/Helper.php
@@ -105,7 +105,7 @@ trait Helper {
 	 * @return string
 	 */
 	public function cleanup_page_slug( $slug, $demo_slug ) {
-		$unhashed = array( 'shop', 'my-account', 'checkout', 'cart', 'blog', 'news', 'lifter-courses', 'courses', 'dashboard', 'my-courses' );
+		$unhashed = array( 'shop', 'my-account', 'checkout', 'cart', 'blog', 'news', 'lifter-courses', 'courses', 'dashboard', 'my-courses', 'memberships' );
 		$slug     = str_replace( $demo_slug, '', $slug );
 		$slug     = str_replace( 'demo', '', $slug );
 		$slug     = ltrim( $slug, '-' );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Allow the membership page for lifterlms to be unhashed so that links from buttons are preserved.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Import Coding School demo GTB or Elementor
2. The button `Join Now` should point to the correct membership page.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/demo-data-exporter#157.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
