### PR TITLE
fix: solve elementor title align and icon size #236

### DIFF
--- a/elementor/src/editor.scss
+++ b/elementor/src/editor.scss
@@ -4,8 +4,8 @@
 		margin-left: 5px;
 
 		.tpc-template-cloud-icon {
-			width: 12px;
-			height: 12px;
+			width: 18px;
+			height: 18px;
 		}
 	}
 }
@@ -566,6 +566,9 @@
 			}
 
 			.ti-tpc-template-library-export {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
 				padding: 50px 0;
 
 				.ti-tpc-template-library-blank-icon {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixed the display style when saving a template in Elementor see image 1
Increased the icon size for TPC in Elementor as it looked off-center and smaller than the surrounding icons.

### Screenshots
![image](https://user-images.githubusercontent.com/23024731/229507083-b1294708-cbad-44f8-b5e1-ec89964c1895.png)

![image](https://user-images.githubusercontent.com/23024731/229507187-3fac9ea2-172f-4cab-8ac2-f5735c7483de.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Create a page with Elementor
2. Click on the **Templates Patterns icon**
3. In the pop-up click on the **Save icon**, The **Save your page to Templates Cloud** message should be center aligned.

<!-- Issues that this pull request closes. -->
Closes #236.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
