### PR TITLE
Fix/cleanup tooltip

### DIFF
--- a/assets/src/Components/CustomTooltip.js
+++ b/assets/src/Components/CustomTooltip.js
@@ -2,10 +2,10 @@ import { Icon, info } from '@wordpress/icons';
 
 import classnames from 'classnames';
 
-const CustomTooltip = ( { children, className, toLeft = false } ) => {
+const CustomTooltip = ( { children, className, toLeft = false, rightOffset = 0 } ) => {
 	const tooltipClassNames = classnames( [ className, 'tiob-tooltip-wrap' ] );
 
-	const ttStyle = toLeft ? { right: 0, left: 'unset' } : {};
+	const ttStyle = toLeft ? { right: rightOffset, left: 'unset' } : {};
 
 	return (
 		<div className={ tooltipClassNames }>

--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -304,7 +304,8 @@ const ImportModal = ( {
 							<span>{ title }</span>
 							{ tooltip && (
 								<CustomTooltip
-									toLeft={ id === 'performanceAddon' }
+									toLeft={ id === 'performanceAddon' || id === 'cleanup' }
+									rightOffset={ id === 'cleanup' ? -90 : 0 }
 								>
 									{ tooltip }
 								</CustomTooltip>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -516,7 +516,7 @@ class Admin {
 		// Previously the library was visited check was stored in a transient. To ensure the notification is not displayed anymore once the user has visited the library
 		// the transient was moved to an option and here we check that if the transient is set we also update the option.
 		$visited_transient = (bool) get_transient( self::VISITED_LIBRARY_OPT );
-		$page_was_visited = get_option( self::VISITED_LIBRARY_OPT, false );
+		$page_was_visited  = get_option( self::VISITED_LIBRARY_OPT, false );
 		if ( $visited_transient && $page_was_visited === false ) {
 			update_option( self::VISITED_LIBRARY_OPT, 'yes' );
 			$page_was_visited = 'yes';

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -20,6 +20,8 @@ class Admin {
 	const IMPORTED_TEMPLATES_COUNT_OPT = 'tiob_premade_imported';
 	const FEEDBACK_DISMISSED_OPT       = 'tiob_feedback_dismiss';
 
+	const VISITED_LIBRARY_OPT = 'tiob_library_visited';
+
 	/**
 	 * Admin page slug
 	 *
@@ -342,7 +344,7 @@ class Admin {
 
 		$dismiss_notice = isset( $_GET['dismiss_notice'] ) && $_GET['dismiss_notice'] === 'yes';
 		if ( $dismiss_notice ) {
-			set_transient( 'tiob_library_visited', true );
+			update_option( self::VISITED_LIBRARY_OPT, 'yes' );
 		}
 
 		$dependencies = ( include TIOB_PATH . 'assets/build/app.asset.php' );
@@ -510,8 +512,16 @@ class Admin {
 		if ( isset( $this->wl_config['starter_sites'] ) && (bool) $this->wl_config['starter_sites'] === true ) {
 			return $array;
 		}
-		$page_was_visited = (bool) get_transient( 'tiob_library_visited' );
-		if ( $this->is_agency_plan() && ! $page_was_visited ) {
+
+		// Previously the library was visited check was stored in a transient. To ensure the notification is not displayed anymore once the user has visited the library
+		// the transient was moved to an option and here we check that if the transient is set we also update the option.
+		$visited_transient = (bool) get_transient( self::VISITED_LIBRARY_OPT );
+		$page_was_visited = get_option( self::VISITED_LIBRARY_OPT, false );
+		if ( $visited_transient && $page_was_visited === false ) {
+			update_option( self::VISITED_LIBRARY_OPT, 'yes' );
+			$page_was_visited = 'yes';
+		}
+		if ( $this->is_agency_plan() && $page_was_visited !== 'yes' ) {
 			$array['notifications']['template-cloud'] = array(
 				'text' => __( 'Great news!  Now you can export your own custom designs to the cloud and then reuse them on other sites.', 'templates-patterns-collection' ),
 				'cta'  => sprintf(


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Changed the way the cleanup tooltip is being displayed.
See the image below:
![image](https://user-images.githubusercontent.com/23024731/230152645-7d18a282-6922-405f-bdb9-e30e74842ccb.png)


Also included a minor fix to an issue reported by @mghenciu on the channel.
The issue was that the notification for using the library feature will appear again after a while even if a user already visited the library page.
Here is an image with the notification:
![image](https://user-images.githubusercontent.com/23024731/230152065-f4f251b4-108c-4c8a-9851-434cdca1d33d.png)

The expected functionality is that once a user visits the Library page from TPC this will be automatically dismissed.
It was dismissed with a transient, but there are cases where the transient will still expire and the notice will reappear.

I changed it so that the dismiss is now stored on an option that will not expire.


### Test instructions
<!-- Describe how this pull request can be tested. -->
How to test:

For the Tooltip issue:
1. Import a starter site.
2. Once the import is done, try to import the same starter site or a new one.
3. The Cleanup toggle should be present.
4. Check the position of the tooltip for the cleanup toggle.

For the Notification:
1. Use a fresh instance and activate TPC
2. Check that the notification is present see the image from above.
3. Click on the "Open Templates Cloud" from the Notification (this will dismiss the notification, only on clicking this button)
4. Check using Transient Manager or a similar plugin that there is no transient called `tiob_library_visited`, additional you can check that the `tiob_library_visited` option is set to `yes`
5. Check that the notification is not displayed anymore after the user action described above.

<!-- Issues that this pull request closes. -->
Closes #231.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
