### PR TITLE
fix: error from TPC inside FSE editor.

### DIFF
--- a/includes/Editor.php
+++ b/includes/Editor.php
@@ -60,6 +60,12 @@ class Editor {
 			return;
 		}
 
+		// Don't load on site editor. Until FSE support in TPC is added.
+		// We can remove this check once Codeinwp/templates-patterns-collection/issues/248 is implemented.
+		if ( $screen->id === 'site-editor' ) {
+			return;
+		}
+
 		wp_register_script(
 			$this->handle,
 			TIOB_URL . 'editor/build/index.js',


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added a check for the `site-editor` screen and, did not load the TPC module as template save or import is not supported yet.
Opened a new ticket #248 to add support for saving FSE templates.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Activate TPC
2. Activate an FSE theme
3. Open the FSE editor, and check that no error is shown and the TPC plugin is not loaded inside the editor.
4. Check that for other instances (Gutenberg Post Edit, Gutenberg Page Edit, Elementor) the TPC is loaded as before.

<!-- Issues that this pull request closes. -->
Closes #246.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
