### PR TITLE
fix: improved elementor styles for light and dark skin #239

### DIFF
--- a/elementor/src/components/templates-content.js
+++ b/elementor/src/components/templates-content.js
@@ -150,7 +150,7 @@ const TemplatesContent = ( {
 				( isGeneral ? (
 					<p>{ 'No templates found. Check again later!' }</p>
 				) : (
-					<p>
+					<p style={ { alignSelf: 'center' } }>
 						{ 'No templates available. Try adding few templates.' }
 					</p>
 				) ) }

--- a/elementor/src/components/templates-content.js
+++ b/elementor/src/components/templates-content.js
@@ -150,7 +150,7 @@ const TemplatesContent = ( {
 				( isGeneral ? (
 					<p>{ 'No templates found. Check again later!' }</p>
 				) : (
-					<p style={ { alignSelf: 'center' } }>
+					<p style={ { marginLeft: '10px' } }>
 						{ 'No templates available. Try adding few templates.' }
 					</p>
 				) ) }

--- a/elementor/src/editor.scss
+++ b/elementor/src/editor.scss
@@ -334,7 +334,7 @@
 							top: 50%;
 							right: 0;
 							transform: translateY(-50%);
-							color: #a4afb7;
+							color: var(--e-a-color-txt, #babfc5);
 						}
 					}
 				}

--- a/elementor/src/editor.scss
+++ b/elementor/src/editor.scss
@@ -183,10 +183,21 @@
 		max-height: 85vh;
 		overflow: auto;
 		padding-top: 25px;
+		background-color: var(--e-a-bg-active, #2f3032);
+		color: var(--e-a-color-txt, #babfc5);
 
 		&.is-dark {
+			background-color: var(--e-a-color-bg-active, #2f3032);
+			color: var(--e-a-color-txt, #babfc5);
 			.dialog-content {
 				.ti-tpc-template-library-templates {
+					.ti-tpc-template-library-templates-header {
+						.ti-tpc-template-library-templates-header-search {
+							input {
+								color: var(--e-a-color-txt);
+							}
+						}
+					}
 					.ti-tpc-template-library-templates-container {
 						.ti-tpc-template-library-templates-table-header {
 							.ti-tpc-template-library-templates-table-column {
@@ -314,6 +325,7 @@
 							font-size: 11px;
 							padding: 8px 15px 8px 0;
 							transition: border .5s;
+							color: var(--e-a-color-txt, #babfc5);
 						}
 
 						i,
@@ -332,6 +344,9 @@
 					display: flex;
 					flex-wrap: wrap;
 					align-items: flex-start;
+					p {
+						padding: 8px 16px;
+					}
 
 					&.is-table {
 						flex-direction: column;
@@ -530,6 +545,7 @@
 
 							.ti-tpc-template-library-template-action {
 								color: #39b54a;
+								background-color: transparent;
 								height: auto;
 								padding: 0;
 								font-size: 11px;
@@ -632,10 +648,11 @@
 				overflow: hidden;
 
 				iframe {
-					height: 150%;
+					height: 145%;
+					width: 145%;
 					position: relative;
 					z-index: 99;
-					transform: scale(.666) translateX(-25%) translateY(-25%);
+					transform: scale(.666) translateX(-24%) translateY(-25%);
 				}
 
 				.is-loading {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Solved alignment issues
Solved some other issues with regard to style consistency and behavior inside the Elementor modal.
Fixed issues with how the import preview modal aligns and the `Insert` button of the templates.

### Screenshots
![image](https://user-images.githubusercontent.com/23024731/235653158-3d2d42be-c6f1-4424-baa9-882df9e70773.png)



### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that inside Elementor the color are visible and they have good contrast for the text
2. Check the alignment when no templates are displayed.
    ![image](https://user-images.githubusercontent.com/23024731/235653354-34049199-03ad-4093-af9d-f3992a24b5dd.png)
3. Check the colors on the light and dark skin of Elementor.
    ![image](https://user-images.githubusercontent.com/23024731/235653830-0b47056c-ca8b-4830-b63a-2594f4422303.png) This can be changed from **Elementor** > **User Preferences**
4. Check the Insert button of templates
    ![image](https://user-images.githubusercontent.com/23024731/235653205-d9cbfbce-7ab3-47cd-b0e8-cce57c912791.png) Before it had a weird background.
5. Check the preview alignment.
    ![image](https://user-images.githubusercontent.com/23024731/235653474-bf1e2a6e-5f6b-4714-bdbc-3f1236e7559a.png) Before it was not aligned properly.

<!-- Issues that this pull request closes. -->
Closes #239.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
