### PR TITLE
chore: supporting changes for Codeinwp/neve-pro-addon#2435

### DIFF
--- a/assets/src/Components/Header.js
+++ b/assets/src/Components/Header.js
@@ -19,10 +19,12 @@ const TabNavigation = ( {
 	isFetching,
 	license,
 } ) => {
-	const buttons = {
-		starterSites: __( 'Starter Sites', 'templates-patterns-collection' ),
-		pageTemplates: __( 'Page Templates', 'templates-patterns-collection' ),
-	};
+	const buttons = {};
+
+	if ( ! tiobDash.hideStarterSites ) {
+		buttons.starterSites = __( 'Starter Sites', 'templates-patterns-collection' );
+		buttons.pageTemplates = __( 'Page Templates', 'templates-patterns-collection' );
+	}
 
 	if ( ! tiobDash.hideMyLibrary ) {
 		buttons.library = __( 'My Library', 'templates-patterns-collection' );

--- a/assets/src/store/reducer.js
+++ b/assets/src/store/reducer.js
@@ -28,7 +28,7 @@ const initialState = {
 	isOnboarding: onboarding.onboarding || false,
 	migrationData: null,
 	themeAction,
-	currentTab: 'starterSites',
+	currentTab: tiobDash.hideStarterSites ? 'library' : 'starterSites',
 	fetching: false,
 	singleTemplateImport: null,
 	templateModal: null,

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -318,7 +318,7 @@ class Admin {
 		);
 
 		if ( isset( $this->wl_config['starter_sites'] ) && (bool) $this->wl_config['starter_sites'] === true &&
-			 ( ! isset( $this->wl_config['my_library'] ) || (bool) $this->wl_config['my_library'] !== true )
+			( ! isset( $this->wl_config['my_library'] ) || (bool) $this->wl_config['my_library'] !== true )
 		) {
 			$library_data['menu_slug'] = $this->page_slug;
 			$library_data['callback']  = array(

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -15,6 +15,8 @@ use TIOB\Importers\Cleanup\Active_State;
  * @package templates-patterns-collection
  */
 class Admin {
+	use White_Label_Config;
+
 	const API = 'api.themeisle.com';
 
 	const IMPORTED_TEMPLATES_COUNT_OPT = 'tiob_premade_imported';
@@ -30,18 +32,15 @@ class Admin {
 	private $page_slug = 'tiob-starter-sites';
 
 	/**
-	 * White label config
-	 *
-	 * @var array
-	 */
-	private $wl_config = null;
-
-	/**
 	 * Option and transient namespace for email skip.
 	 *
 	 * @var string
 	 */
 	private $skip_email_subscribe_namespace = 'tpc_skip_email_subscribe';
+
+	public static function get_templates_cloud_endpoint() {
+		return 'https://' . self::API . '/templates-cloud/';
+	}
 
 	/**
 	 * Initialize the Admin.
@@ -55,13 +54,7 @@ class Admin {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
 		add_filter( 'ti_tpc_editor_data', array( $this, 'add_tpc_editor_data' ), 20 );
 
-		$white_label_module = get_option( 'nv_pro_white_label_status' );
-		if ( ! empty( $white_label_module ) && (bool) $white_label_module === true ) {
-			$branding = get_option( 'ti_white_label_inputs' );
-			if ( ! empty( $branding ) ) {
-				$this->wl_config = json_decode( $branding, true );
-			}
-		}
+		$this->setup_white_label();
 
 		add_action( 'wp_ajax_skip_subscribe', array( $this, 'skip_subscribe' ) );
 		add_action( 'wp_ajax_nopriv_skip_subscribe', array( $this, 'skip_subscribe' ) );
@@ -288,6 +281,10 @@ class Admin {
 	 * @return bool|void
 	 */
 	public function register() {
+		if ( $this->is_library_disabled() && $this->is_starter_sites_disabled() ) {
+			return false;
+		}
+
 		$style = 'display:inline-block;';
 
 		if ( ! is_rtl() ) {
@@ -317,9 +314,7 @@ class Admin {
 			'callback'   => '',
 		);
 
-		if ( isset( $this->wl_config['starter_sites'] ) && (bool) $this->wl_config['starter_sites'] === true &&
-			( ! isset( $this->wl_config['my_library'] ) || (bool) $this->wl_config['my_library'] !== true )
-		) {
+		if ( $this->is_starter_sites_disabled() && ! $this->is_library_disabled() ) {
 			$library_data['menu_slug'] = $this->page_slug;
 			$library_data['callback']  = array(
 				$this,
@@ -330,7 +325,7 @@ class Admin {
 		}
 		$this->add_theme_page_for_tiob( $starter_site_data );
 
-		if ( isset( $this->wl_config['my_library'] ) && (bool) $this->wl_config['my_library'] === true ) {
+		if ( $this->is_library_disabled() ) {
 			return false;
 		}
 		$this->add_theme_page_for_tiob( $library_data );
@@ -430,10 +425,10 @@ class Admin {
 			'hasFileSystem'       => WP_Filesystem(),
 			'themesURL'           => admin_url( 'themes.php' ),
 			'themeAction'         => $this->get_theme_action(),
-			'brandedTheme'        => isset( $this->wl_config['theme_name'] ) ? $this->wl_config['theme_name'] : false,
-			'hideStarterSites'    => isset( $this->wl_config['starter_sites'] ) ? $this->wl_config['starter_sites'] : false,
-			'hideMyLibrary'       => isset( $this->wl_config['my_library'] ) ? $this->wl_config['my_library'] : false,
-			'endpoint'            => TPC_TEMPLATES_CLOUD_ENDPOINT,
+			'brandedTheme'        => $this->get_whitelabel_name(),
+			'hideStarterSites'    => $this->is_starter_sites_disabled(),
+			'hideMyLibrary'       => $this->is_library_disabled(),
+			'endpoint'            => ( defined( 'TPC_TEMPLATES_CLOUD_ENDPOINT' ) ) ? TPC_TEMPLATES_CLOUD_ENDPOINT : self::get_templates_cloud_endpoint(),
 			'params'              => array(
 				'site_url'   => get_site_url(),
 				'license_id' => License::get_license_data()->key,
@@ -545,7 +540,7 @@ class Admin {
 		$array['onboarding'] = $api;
 
 		// Do not display the notification if starter sites are disabled
-		if ( isset( $this->wl_config['starter_sites'] ) && (bool) $this->wl_config['starter_sites'] === true ) {
+		if ( $this->is_starter_sites_disabled() ) {
 			return $array;
 		}
 

--- a/includes/Editor.php
+++ b/includes/Editor.php
@@ -15,13 +15,7 @@ use TIOB\Main;
  * @package templates-patterns-collection
  */
 class Editor {
-
-	/**
-	 * White label config
-	 *
-	 * @var array
-	 */
-	private $wl_config = null;
+	use White_Label_Config;
 
 	const ALLOWED_POST_TYPES = array( 'post', 'page', 'neve_custom_layouts' );
 
@@ -45,20 +39,14 @@ class Editor {
 	 * Initialize the Admin.
 	 */
 	public function init() {
-		$white_label_module = get_option( 'nv_pro_white_label_status' );
-		if ( ! empty( $white_label_module ) && (bool) $white_label_module === true ) {
-			$branding = get_option( 'ti_white_label_inputs' );
-			if ( ! empty( $branding ) ) {
-				$this->wl_config = json_decode( $branding, true );
-			}
-		}
+		$this->setup_white_label();
 
-		if ( isset( $this->wl_config['my_library'] ) && (bool) $this->wl_config['my_library'] === true ) {
-			return false;
+		if ( $this->is_library_disabled() ) {
+			return;
 		}
 
 		if ( ! defined( 'TPC_TEMPLATES_CLOUD_ENDPOINT' ) ) {
-			define( 'TPC_TEMPLATES_CLOUD_ENDPOINT', 'https://api.themeisle.com/templates-cloud/' );
+			define( 'TPC_TEMPLATES_CLOUD_ENDPOINT', Admin::get_templates_cloud_endpoint() );
 		}
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_block' ), 11 );
 		$this->register_post_meta();

--- a/includes/Editor.php
+++ b/includes/Editor.php
@@ -16,6 +16,13 @@ use TIOB\Main;
  */
 class Editor {
 
+	/**
+	 * White label config
+	 *
+	 * @var array
+	 */
+	private $wl_config = null;
+
 	const ALLOWED_POST_TYPES = array( 'post', 'page', 'neve_custom_layouts' );
 
 	/**
@@ -38,6 +45,18 @@ class Editor {
 	 * Initialize the Admin.
 	 */
 	public function init() {
+		$white_label_module = get_option( 'nv_pro_white_label_status' );
+		if ( ! empty( $white_label_module ) && (bool) $white_label_module === true ) {
+			$branding = get_option( 'ti_white_label_inputs' );
+			if ( ! empty( $branding ) ) {
+				$this->wl_config = json_decode( $branding, true );
+			}
+		}
+
+		if ( isset( $this->wl_config['my_library'] ) && (bool) $this->wl_config['my_library'] === true ) {
+			return false;
+		}
+
 		if ( ! defined( 'TPC_TEMPLATES_CLOUD_ENDPOINT' ) ) {
 			define( 'TPC_TEMPLATES_CLOUD_ENDPOINT', 'https://api.themeisle.com/templates-cloud/' );
 		}

--- a/includes/Elementor.php
+++ b/includes/Elementor.php
@@ -15,11 +15,18 @@ use TIOB\Main;
  * @package templates-patterns-collection
  */
 class Elementor {
+	use White_Label_Config;
 
 	/**
 	 * Initialize the Admin.
 	 */
 	public function init() {
+		$this->setup_white_label();
+
+		if ( $this->is_library_disabled() ) {
+			return;
+		}
+
 		add_action( 'elementor/editor/before_enqueue_scripts', array( $this, 'register_script' ), 999 );
 		add_action( 'elementor/editor/before_enqueue_styles', array( $this, 'register_style' ) );
 		add_action( 'elementor/preview/enqueue_styles', array( $this, 'register_style' ) );
@@ -45,7 +52,7 @@ class Elementor {
 			apply_filters(
 				'ti_tpc_editor_data',
 				array(
-					'endpoint'         => TPC_TEMPLATES_CLOUD_ENDPOINT,
+					'endpoint'         => ( defined( 'TPC_TEMPLATES_CLOUD_ENDPOINT' ) ) ? TPC_TEMPLATES_CLOUD_ENDPOINT : Admin::get_templates_cloud_endpoint(),
 					'params'           => array(
 						'site_url'   => get_site_url(),
 						'license_id' => apply_filters( 'tiob_license_key', 'free' ),

--- a/includes/White_Label_Config.php
+++ b/includes/White_Label_Config.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Contains common methods for the white label Neve settings.
+ *
+ * @package    templates-patterns-collection
+ */
+
+namespace TIOB;
+
+/**
+ * Trait White_Label_Config
+ *
+ * @package templates-patterns-collection
+ */
+trait White_Label_Config {
+	/**
+	 * White label config
+	 *
+	 * @var array
+	 */
+	private $wl_config = null;
+
+	/**
+	 * Setup white label config.
+	 */
+	public function setup_white_label() {
+		$white_label_module = get_option( 'nv_pro_white_label_status' );
+		if ( ! empty( $white_label_module ) && (bool) $white_label_module === true ) {
+			$branding = get_option( 'ti_white_label_inputs' );
+			if ( ! empty( $branding ) ) {
+				$this->wl_config = json_decode( $branding, true );
+			}
+		}
+	}
+
+	/**
+	 * Check if library is disabled.
+	 *
+	 * @return bool
+	 */
+	public function is_library_disabled() {
+		if ( isset( $this->wl_config['my_library'] ) && (bool) $this->wl_config['my_library'] === true ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check if starter sites are disabled.
+	 *
+	 * @return bool
+	 */
+	public function is_starter_sites_disabled() {
+		if ( isset( $this->wl_config['starter_sites'] ) && (bool) $this->wl_config['starter_sites'] === true ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check if theme name is set.
+	 *
+	 * @return bool
+	 */
+	public function get_whitelabel_name() {
+		return isset( $this->wl_config['theme_name'] ) ? $this->wl_config['theme_name'] : false;
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Allow My Library to be used as a default tab if the Starter Site is Hidden and the Library is available.
Do not enqueue Library Import and Save inside the editor if the Library is hidden.
Refactored White Label logic to a Trait so that it can be reused where needed.
Refactored templates cloud endpoint location as it will throw an error when the library is not loaded and only starter sites is enabled.
Supporting changes for Codeinwp/neve-pro-addon#2435

### Test instructions
<!-- Describe how this pull request can be tested. -->
Testing steps can be found on the main issue.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2435.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
