### PR TITLE
fix: solve error reported on import from preview

### DIFF
--- a/elementor/src/data/utils.js
+++ b/elementor/src/data/utils.js
@@ -1,0 +1,25 @@
+/**
+ * Will attach the post model to the window object if it doesn't exist.
+ *
+ * @param id of the page/post
+ * @returns {Promise<void>}
+ */
+export const setPostModel = async ( elementorId ) => {
+    if ( undefined !== window.tiTpc.postModel ) {
+        return;
+    }
+
+    let postModel = undefined;
+    if ( 'page' === window.tiTpc.postType ) {
+        postModel = await new wp.api.models.Page( { id: elementorId } );
+    } else {
+        postModel = await new wp.api.models.Post( { id: elementorId } );
+    }
+
+    if ( undefined === postModel ) {
+        return;
+    }
+
+    window.tiTpc.postModel = postModel;
+    await window.tiTpc.postModel.fetch();
+}

--- a/elementor/src/export.js
+++ b/elementor/src/export.js
@@ -10,6 +10,7 @@ import {
 	exportTemplate,
 	updateTemplate,
 } from './data/templates-cloud/index.js';
+import { setPostModel } from './data/utils';
 
 if ( parseInt( window.tiTpc.tier ) === 3 ) {
 	elementor.on( 'document:loaded', () => {
@@ -23,13 +24,7 @@ if ( parseInt( window.tiTpc.tier ) === 3 ) {
 			}
 
 			const id = elementor.config.document.id;
-			if ( 'page' === window.tiTpc.postType ) {
-				window.tiTpc.postModel = await new wp.api.models.Page( { id } );
-			} else {
-				window.tiTpc.postModel = await new wp.api.models.Post( { id } );
-			}
-
-			await window.tiTpc.postModel.fetch();
+			await setPostModel( id );
 
 			const publishButton = document.querySelector(
 				'button#elementor-panel-saver-button-publish'

--- a/elementor/src/template-library.js
+++ b/elementor/src/template-library.js
@@ -155,6 +155,14 @@ const TemplateLibrary = ( { currentTab, setFetching } ) => {
 			} );
 		}
 
+		if ( undefined === window.tiTpc.postModel ) {
+			if ( 'page' === window.tiTpc.postType ) {
+				window.tiTpc.postModel = await new wp.api.models.Page( { id } );
+			} else {
+				window.tiTpc.postModel = await new wp.api.models.Post( { id } );
+			}
+		}
+
 		if (
 			undefined !== meta &&
 			0 < Object.keys( tryParseJSON( meta ) || {} ).length

--- a/elementor/src/template-library.js
+++ b/elementor/src/template-library.js
@@ -7,6 +7,7 @@ import { Fragment, useState } from '@wordpress/element';
 import Header from './components/header.js';
 import Content from './components/content.js';
 import { importTemplate } from './data/templates-cloud/index.js';
+import { setPostModel } from './data/utils';
 
 const { omit } = lodash;
 
@@ -155,13 +156,8 @@ const TemplateLibrary = ( { currentTab, setFetching } ) => {
 			} );
 		}
 
-		if ( undefined === window.tiTpc.postModel ) {
-			if ( 'page' === window.tiTpc.postType ) {
-				window.tiTpc.postModel = await new wp.api.models.Page( { id } );
-			} else {
-				window.tiTpc.postModel = await new wp.api.models.Post( { id } );
-			}
-		}
+		const elementorId = elementor.config.document.id;
+		await setPostModel( elementorId );
 
 		if (
 			undefined !== meta &&


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
When there is no license inside TPC the `window.tiTpc.postModel` is `undefined` this is because it is only instantiated for versions that have a license so that the export template works.
However, this is also used when importing a template from the preview.

I added a condition that will instantiate the prop if it is not defined.
Refactored the logic to a separate function to be reused in both instances.

### Screenshots
![image](https://user-images.githubusercontent.com/23024731/236479746-d11b883d-247d-44a8-be8c-32a02f3d7b65.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On a fresh instance with only Neve Free, TPC, and Elementor
2. Create a new Page, and import a Page Template using the Import Button from the Preview Window see Pic. 1
3. No error should be thrown in the console and the modal should close by itself.

<!-- Issues that this pull request closes. -->
Closes #252.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
