### PR TITLE
chore: allow post types from pods to be imported

### DIFF
--- a/includes/Importers/Plugin_Importer.php
+++ b/includes/Importers/Plugin_Importer.php
@@ -52,6 +52,7 @@ class Plugin_Importer {
 		'wpzoom-addons-for-beaver-builder' => 'wpzoom-bb-addon-pack.php',
 		'recipe-card-blocks-by-wpzoom'     => 'wpzoom-recipe-card.php',
 		'restrict-content'                 => 'restrictcontent.php',
+		'pods'                             => 'init.php',
 	);
 
 	public function __construct() {

--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -368,6 +368,32 @@ class WP_Import extends WP_Importer {
 	}
 
 	/**
+	 * Check whether the post type is a Pods plugin post type.
+	 *
+	 * @param string $post_type The post type.
+	 *
+	 * @return bool
+	 */
+	private function is_post_type_of_pods_plugin( $post_type ) {
+		if (! ( function_exists( 'pods_api' ) && class_exists( 'Pod', true ) ) ) {
+			return false;
+		}
+		$api             = pods_api();
+		$pods_post_types = $api->load_pods(
+			[
+				'type'    => 'post_type',
+				'refresh' => true,
+			]
+		);
+		foreach ( $pods_post_types as $pod_post_type ) {
+			if ( $pod_post_type['name'] === $post_type ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Create new posts based on import information
 	 *
 	 * Posts marked as having a parent which doesn't exist will become top level items.
@@ -381,9 +407,11 @@ class WP_Import extends WP_Importer {
 		foreach ( $this->posts as $post ) {
 			$post = apply_filters( 'wp_import_post_data_raw', $post );
 			if ( ! post_type_exists( $post['post_type'] ) ) {
-				$this->logger->log( "Failed to import {$post['post_title']}. Invalid post type {$post['post_type']}" );
-				do_action( 'wp_import_post_exists', $post );
-				continue;
+				if ( ! $this->is_post_type_of_pods_plugin( $post['post_type'] ) ) {
+					$this->logger->log( "Failed to import {$post['post_title']}. Invalid post type {$post['post_type']}" );
+					do_action( 'wp_import_post_exists', $post );
+					continue;
+				}
 			}
 			if ( isset( $this->processed_posts[ $post['post_id'] ] ) && ! empty( $post['post_id'] ) ) {
 				continue;

--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -375,15 +375,15 @@ class WP_Import extends WP_Importer {
 	 * @return bool
 	 */
 	private function is_post_type_of_pods_plugin( $post_type ) {
-		if (! ( function_exists( 'pods_api' ) && class_exists( 'Pod', true ) ) ) {
+		if ( ! ( function_exists( 'pods_api' ) && class_exists( 'Pod', true ) ) ) {
 			return false;
 		}
 		$api             = pods_api();
 		$pods_post_types = $api->load_pods(
-			[
+			array(
 				'type'    => 'post_type',
 				'refresh' => true,
-			]
+			)
 		);
 		foreach ( $pods_post_types as $pod_post_type ) {
 			if ( $pod_post_type['name'] === $post_type ) {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Allow Import from PODS plugin exports.

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Import the Podcast Starter Site
2. Check that custom post types for the Pods plugin are imported.

References: Codeinwp/demo-data-exporter/issues/163
<!-- Issues that this pull request closes. -->
Closes Codeinwp/demo-data-exporter/issues/161.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
