### PR TITLE
fix: php8.1 warning on import #265

### DIFF
--- a/includes/Importers/Cleanup/Active_State.php
+++ b/includes/Importers/Cleanup/Active_State.php
@@ -117,6 +117,9 @@ class Active_State {
 	 * @return void
 	 */
 	final public function add( $key, $data ) {
+		if ( empty( $this->state ) ) {
+			$this->state = array();
+		}
 		$this->state[ $key ] = $data;
 		set_transient( self::STATE_NAME, $this->state, 24 * self::HOUR_IN_SECONDS );
 	}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added a guard condition to ensure the `$state` is an array prior to usage if `false` or other empty values are used.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On an instance of WordPress with PHP 8.1
2. Import a Starter Site
3. Check the PHP error logs that no error is reported.

<!-- Issues that this pull request closes. -->
Closes #265.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
