### PR TITLE
Documentation notice after import

### DIFF
--- a/assets/src/Components/DocNotice.js
+++ b/assets/src/Components/DocNotice.js
@@ -1,0 +1,27 @@
+import { Icon } from '@wordpress/components';
+
+const DocNotice = ( { data } ) => {
+	const { text, url } = data;
+
+	if ( ! text ) {
+		return null;
+	}
+
+	return (
+		<div className="doc-notice">
+			{ url ? (
+				<a
+					href={ url }
+					target="_blank"
+					rel="external noreferrer noopener"
+				>
+					<Icon icon="external" /> { text }
+				</a>
+			) : (
+				<p>{ text }</p>
+			) }
+		</div>
+	);
+};
+
+export default DocNotice;

--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -17,6 +17,7 @@ import classnames from 'classnames';
 import ImportModalError from './ImportModalError';
 import ImportModalMock from './ImportModalMock';
 import CustomTooltip from './CustomTooltip';
+import DocNotice from './DocNotice';
 
 import {
 	createInterpolateElement,
@@ -826,6 +827,17 @@ const ImportModal = ( {
 			) : (
 				<>
 					<div className="modal-body">
+						{ 'done' === currentStep &&
+							! error &&
+							siteData.doc_url && (
+								<DocNotice
+									data={ {
+										text: __( 'Learn more about this starter site', 'templates-patterns-collection' ),
+										url: siteData.doc_url,
+									} }
+								/>
+							)
+						}
 						{ ! importing && 'done' !== currentStep && ! error ? (
 							<>
 								<ModalHead />

--- a/assets/src/scss/_docnotice.scss
+++ b/assets/src/scss/_docnotice.scss
@@ -1,0 +1,13 @@
+.doc-notice {
+  background: #e5f1f7;
+  color: #0071ae;
+  width: 100%;
+  border-radius: 5px;
+  padding: 10px;
+  margin-top: 0;
+  margin-bottom: 30px;
+  a {
+    color: #0071ae;
+    text-decoration: none;
+  }
+}

--- a/assets/src/style.scss
+++ b/assets/src/style.scss
@@ -14,9 +14,9 @@
 @import "scss/library";
 @import "scss/demo-site-templates";
 @import "scss/notification";
+@import "scss/docnotice";
 @import "scss/custom-tooltip";
 @import "scss/license";
 @import "scss/feedback";
 
 @import "scss/media-queries";
-

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -579,7 +579,7 @@ class Admin {
 		}
 
 		// Previously the library was visited check was stored in a transient. To ensure the notification is not displayed anymore once the user has visited the library
-		// the transient was moved to an option and here we check that if the transient is set we also update the option.
+		// the transient was moved to an option and here we check that if the transient is set and we also update the option.
 		$visited_transient = (bool) get_transient( self::VISITED_LIBRARY_OPT );
 		$page_was_visited  = get_option( self::VISITED_LIBRARY_OPT, false );
 		if ( $visited_transient && $page_was_visited === false ) {


### PR DESCRIPTION
### Summary
Added the documentation notice after the import. The documentation notice is only visible if the import process is successful and if the starter site has the _doc_url_ property defined in this file: https://github.com/Codeinwp/demo-data-exporter/blob/master/front-end/class-dde-frontend.php

### Test instructions
- Add the following lines to your theme's `functions.php` file
```
define( 'TPC_USE_STAGING', true );
define( 'TPC_API_STAGING', 'https://demosites.io/wp-json/demosites-api/sites' );
```
- Import the podcast starter site as it's the only one that has a doc link
- Check if the notification appears in the modal after the import
- Check if the link works well


Note: I still have to add the doc_url parameter inside the exporter, I'm waiting for an answer regarding the links.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve#3956, #247.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
