### PR TITLE
Template name is not updating

### DIFF
--- a/assets/src/Components/CloudLibrary/ListItem.js
+++ b/assets/src/Components/CloudLibrary/ListItem.js
@@ -208,7 +208,9 @@ const ListItem = ( {
 			{ userTemplate && (
 				<div className="controls">
 					{ item.link ? (
-						<Tooltip text={ __( 'This template is synced to a page.' ) }>
+						<Tooltip
+							text={ __( 'This template is synced to a page.' ) }
+						>
 							<Button
 								label={ __( 'Edit' ) }
 								icon={ edit }
@@ -231,7 +233,15 @@ const ListItem = ( {
 							className={ classnames( {
 								'is-loading': 'updating' === isLoading,
 							} ) }
-							onClick={ () => isEditing ? updateItem : setEditing( ! isEditing ) }
+							onClick={ ( e ) => {
+								if ( isEditing ) {
+									updateItem( e ).then( () =>
+										setEditing( ! isEditing )
+									);
+									return;
+								}
+								setEditing( ! isEditing );
+							} }
 						>
 							{ isEditing ? __( 'Update' ) : __( 'Edit' ) }
 						</Button>


### PR DESCRIPTION
### Summary
I've changed the action that the Edit / Update button did. Previously, it was calling the `updateItem` function but not the editing flag.

### Test instructions
1. Save a block to the Template Cloud 
2. Go to Neve > My Library and try to Edit its name -> click on Update
(Follow this video to replicate the issue https://vertis.d.pr/v/NlgF9k )

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-cloud#75.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
