### PR TITLE
Save logs to transient

### DIFF
--- a/assets/src/Components/ImportModalError.js
+++ b/assets/src/Components/ImportModalError.js
@@ -1,7 +1,30 @@
 import { Dashicon, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import {useEffect, useState} from "@wordpress/element";
+import {getLogsFromServer} from "../../../onboarding/src/utils/rest";
+import {textToFileURL} from "../../../onboarding/src/utils/common";
 
 const ImportModalError = ( { message, code } ) => {
+
+	const [logs, setLogs] = useState( {} );
+
+	useEffect(() => {
+		getLogsFromServer({
+			success: function (response) {
+				setLogs({
+					raw: response,
+					url: textToFileURL(response),
+				});
+			},
+		});
+
+		return () => {
+			if ( logs?.url ) {
+				URL.revokeObjectURL(logs.url);
+			}
+		}
+	}, []);
+
 	return (
 		<div className="well error">
 			{ message && (
@@ -29,10 +52,17 @@ const ImportModalError = ( { message, code } ) => {
 				) }
 				<li>
 					{ __( 'Error log', 'templates-patterns-collection' ) }:{ ' ' }
-					<Button isLink href={ tiobDash.onboarding.logUrl }>
-						{ tiobDash.onboarding.logUrl }
-						<Dashicon icon="external" />
-					</Button>
+					<a download={"ti_theme_onboarding.log"} href={logs.url}>
+						{ __( 'Download Logs File', 'templates-patterns-collection' ) }
+					</a>
+					<details>
+						<summary>
+							{ __( 'See logs', 'templates-patterns-collection' ) }
+						</summary>
+						<div>
+							{ logs.raw }
+						</div>
+					</details>
 				</li>
 			</ul>
 		</div>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -78,7 +78,7 @@ class Admin {
 		add_action( 'wp_ajax_mark_onboarding_done', array( $this, 'mark_onboarding_done' ) );
 		add_action( 'wp_ajax_nopriv_mark_onboarding_done', array( $this, 'mark_onboarding_done' ) );
 
-		add_action( 'wp_ajax_external_get_logs', array( $this, 'external_get_logs' ) );
+		add_action( 'wp_ajax_tpc_get_logs', array( $this, 'external_get_logs' ) );
 
 		$this->register_feedback_settings();
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -78,6 +78,8 @@ class Admin {
 		add_action( 'wp_ajax_mark_onboarding_done', array( $this, 'mark_onboarding_done' ) );
 		add_action( 'wp_ajax_nopriv_mark_onboarding_done', array( $this, 'mark_onboarding_done' ) );
 
+        add_action( 'wp_ajax_external_get_logs', array( $this, 'external_get_logs') );
+
 		$this->register_feedback_settings();
 
 		$this->register_prevent_clone_hooks();
@@ -954,7 +956,7 @@ class Admin {
 			'homeUrl'    => esc_url( home_url() ),
 			'i18n'       => $this->get_strings(),
 			'onboarding' => false,
-			'logUrl'     => WP_Filesystem() ? Logger::get_instance()->get_log_url() : null,
+			'logUrl'     => Logger::get_instance()->get_log_url(),
 		);
 
 		$is_onboarding = isset( $_GET['onboarding'] ) && $_GET['onboarding'] === 'yes';
@@ -1205,4 +1207,25 @@ class Admin {
 		return true;
 	}
 
+    /**
+     * Get logs from transient via ajax.
+     */
+    public function external_get_logs() {
+
+
+        $nonce = $_POST['nonce'];
+
+        if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+            wp_die( __( 'Nonce verification failed', 'templates-patterns-collection' ) );
+        }
+
+        $data = get_transient( Logger::$log_transient_name );
+
+        if ( ! empty( $data ) ) {
+            echo $data;
+            wp_die();
+        }
+
+        wp_die( __( 'No logs found', 'templates-patterns-collection' ) );
+    }
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -78,7 +78,7 @@ class Admin {
 		add_action( 'wp_ajax_mark_onboarding_done', array( $this, 'mark_onboarding_done' ) );
 		add_action( 'wp_ajax_nopriv_mark_onboarding_done', array( $this, 'mark_onboarding_done' ) );
 
-        add_action( 'wp_ajax_external_get_logs', array( $this, 'external_get_logs') );
+		add_action( 'wp_ajax_external_get_logs', array( $this, 'external_get_logs' ) );
 
 		$this->register_feedback_settings();
 
@@ -1207,25 +1207,24 @@ class Admin {
 		return true;
 	}
 
-    /**
-     * Get logs from transient via ajax.
-     */
-    public function external_get_logs() {
+	/**
+	 * Get logs from transient via ajax.
+	 */
+	public function external_get_logs() {
 
+		$nonce = $_POST['nonce'];
 
-        $nonce = $_POST['nonce'];
+		if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+			wp_die( __( 'Nonce verification failed', 'templates-patterns-collection' ) );
+		}
 
-        if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
-            wp_die( __( 'Nonce verification failed', 'templates-patterns-collection' ) );
-        }
+		$data = get_transient( Logger::$log_transient_name );
 
-        $data = get_transient( Logger::$log_transient_name );
+		if ( ! empty( $data ) ) {
+			echo $data;
+			wp_die();
+		}
 
-        if ( ! empty( $data ) ) {
-            echo $data;
-            wp_die();
-        }
-
-        wp_die( __( 'No logs found', 'templates-patterns-collection' ) );
-    }
+		wp_die( __( 'No logs found', 'templates-patterns-collection' ) );
+	}
 }

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -173,13 +173,6 @@ class Logger {
 	}
 
 	/**
-	 * Clear the log file.
-	 */
-	private function clear_log() {
-		delete_transient( self::$log_transient_name );
-	}
-
-	/**
 	 * Log entry.
 	 *
 	 * @param string $message log message.

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -45,21 +45,21 @@ class Logger {
 	 *
 	 * @var string
 	 */
-    private $log_file_name = 'ti-theme-onboarding.log';
+	private $log_file_name = 'ti-theme-onboarding.log';
 
-    /**
-     * Log transient name.
-     *
-     * @var string
-     */
+	/**
+	 * Log transient name.
+	 *
+	 * @var string
+	 */
 	public static $log_transient_name = 'ti_theme_onboarding';
 
-    /**
-     * The expiration time for the transient.
-     *
-     * @var float|int
-     */
-    private $log_transient_expiration = 2 * WEEK_IN_SECONDS;
+	/**
+	 * The expiration time for the transient.
+	 *
+	 * @var float|int
+	 */
+	private $log_transient_expiration = 2 * WEEK_IN_SECONDS;
 
 	/**
 	 * @var string
@@ -83,9 +83,9 @@ class Logger {
 			return;
 		}
 		require_once( ABSPATH . 'wp-admin/includes/file.php' ); // you have to load this file
-		add_action( 'shutdown', array( $this, 'log_to_transient') );
+		add_action( 'shutdown', array( $this, 'log_to_transient' ) );
 		$this->set_log_path();
-        $this->migrate_from_file_to_transient();
+		$this->migrate_from_file_to_transient();
 		$this->log_client_info();
 	}
 
@@ -199,14 +199,14 @@ class Logger {
 	 */
 	public function log_to_transient() {
 
-        $transient_data = get_transient( self::$log_transient_name );
+		$transient_data = get_transient( self::$log_transient_name );
 
-        if ( ! $transient_data ) {
-            $transient_data = '';
-        }
+		if ( ! $transient_data ) {
+			$transient_data = '';
+		}
 
-        $transient_data .= $this->log_string;
-        set_transient( self::$log_transient_name, $transient_data, $this->log_transient_expiration );
+		$transient_data .= $this->log_string;
+		set_transient( self::$log_transient_name, $transient_data, $this->log_transient_expiration );
 	}
 
 	/**
@@ -229,27 +229,27 @@ class Logger {
 		return $this->log_file_path_url . $this->log_transient_name;
 	}
 
-    /**
-     * Migrate from file to transient.
-     */
-    public function migrate_from_file_to_transient() {
-        $log_file = $this->log_file_path . $this->log_file_name;
-        global $wp_filesystem;
-        WP_Filesystem();
+	/**
+	 * Migrate from file to transient.
+	 */
+	public function migrate_from_file_to_transient() {
+		$log_file = $this->log_file_path . $this->log_file_name;
+		global $wp_filesystem;
+		WP_Filesystem();
 
-        $has_file = file_exists( $log_file );
+		$has_file = file_exists( $log_file );
 
-        if ( ! $has_file ) {
-            return;
-        }
+		if ( ! $has_file ) {
+			return;
+		}
 
-        $content  = $wp_filesystem->get_contents( $log_file );
-        $this->log_string .= $content;
+		$content           = $wp_filesystem->get_contents( $log_file );
+		$this->log_string .= $content;
 
-        $this->log_to_transient();
+		$this->log_to_transient();
 
-        if ( is_writable( $log_file ) ) {
-            unlink( $log_file );
-        }
-    }
+		if ( is_writable( $log_file ) ) {
+			unlink( $log_file );
+		}
+	}
 }

--- a/onboarding/src/Components/ImportError.js
+++ b/onboarding/src/Components/ImportError.js
@@ -1,8 +1,31 @@
 /* global tiobDash */
 import { Dashicon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import {useEffect, useState} from "@wordpress/element";
+import {getLogsFromServer} from "../utils/rest";
+import {textToFileURL} from "../utils/common";
 
 const ImportError = ( { message, code } ) => {
+
+	const [logs, setLogs] = useState( {} );
+
+	useEffect(() => {
+		getLogsFromServer({
+			success: function (response) {
+				setLogs({
+					raw: response,
+					url: textToFileURL(response),
+				});
+			},
+		});
+
+		return () => {
+			if ( logs?.url ) {
+				URL.revokeObjectURL(logs.url);
+			}
+		}
+	}, []);
+
 	return (
 		<div className="ob-error-wrap">
 			{ message && (
@@ -30,10 +53,17 @@ const ImportError = ( { message, code } ) => {
 				) }
 				<li>
 					{ __( 'Error log', 'templates-patterns-collection' ) }:{ ' ' }
-					<a href={ tiobDash.onboarding.logUrl }>
-						{ tiobDash.onboarding.logUrl }
-						<Dashicon icon="external" />
+					<a download={"ti_theme_onboarding.log"} href={logs.url}>
+						{ __( 'Download Logs File', 'templates-patterns-collection' ) }
 					</a>
+					<details>
+						<summary>
+							{ __( 'See logs', 'templates-patterns-collection' ) }
+						</summary>
+						<div>
+							{ logs.raw }
+						</div>
+					</details>
 				</li>
 			</ul>
 		</div>

--- a/onboarding/src/utils/common.js
+++ b/onboarding/src/utils/common.js
@@ -37,10 +37,22 @@ const sendPostMessage = ( data ) => {
 	);
 };
 
+/**
+ * Convert text to file URL.
+ *
+ * @param {string} text - Text to convert
+ * @returns {string} - File URL
+ */
+const textToFileURL = ( text ) => {
+	const blob = new Blob( [ text ], { type: 'text/plain' } );
+	return URL.createObjectURL( blob );
+}
+
 export {
 	trailingSlashIt,
 	untrailingSlashIt,
 	sendPostMessage,
 	EDITOR_MAP,
 	ONBOARDING_CAT,
+	textToFileURL,
 };

--- a/onboarding/src/utils/rest.js
+++ b/onboarding/src/utils/rest.js
@@ -129,18 +129,3 @@ export const getLogsFromServer = (args) => {
 		...args
 	})
 }
-
-/**
- * Create and download txt file.
- *
- * @param {any} data - Data to write to file
- * @param {string} fileName - Name of the file to download
- */
-export const createAndDownloadTxtFile = (data, fileName = "ti_theme_onboarding.log") => {
-	const element = document.createElement("a");
-	const file = new Blob([data], {type: 'text/plain'});
-	element.href = URL.createObjectURL(file);
-	element.download = fileName;
-	document.body.appendChild(element); // Required for this to work in FireFox
-	element.click();
-}

--- a/onboarding/src/utils/rest.js
+++ b/onboarding/src/utils/rest.js
@@ -113,3 +113,34 @@ export const track = async ( trackingId = '', data ) => {
 		return false;
 	}
 };
+
+/**
+ * Get logs from server using ajax.
+ * @param {Object} args - ajax arguments
+ */
+export const getLogsFromServer = (args) => {
+	jQuery.ajax({
+		type: 'post',
+		url: ajaxurl,
+		data: {
+			action: 'external_get_logs',
+			nonce: tiobDash.nonce,
+		},
+		...args
+	})
+}
+
+/**
+ * Create and download txt file.
+ *
+ * @param {any} data - Data to write to file
+ * @param {string} fileName - Name of the file to download
+ */
+export const createAndDownloadTxtFile = (data, fileName = "ti_theme_onboarding.log") => {
+	const element = document.createElement("a");
+	const file = new Blob([data], {type: 'text/plain'});
+	element.href = URL.createObjectURL(file);
+	element.download = fileName;
+	document.body.appendChild(element); // Required for this to work in FireFox
+	element.click();
+}

--- a/onboarding/src/utils/rest.js
+++ b/onboarding/src/utils/rest.js
@@ -123,7 +123,7 @@ export const getLogsFromServer = (args) => {
 		type: 'post',
 		url: ajaxurl,
 		data: {
-			action: 'external_get_logs',
+			action: 'tpc_get_logs',
 			nonce: tiobDash.nonce,
 		},
 		...args


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Move the logs to transient instead of file.

For saving the data we will use a transient with 2 weeks expiration time. Instead of sharing the link to the log files, users will download it and send it to support.

![image](https://github.com/Codeinwp/templates-patterns-collection/assets/17597852/850c884a-da09-4952-b89d-0a4a91bc5415)

![image](https://github.com/Codeinwp/templates-patterns-collection/assets/17597852/20690669-3050-4f34-babf-ae66190ecd10)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- When import a site, try to make it to give an error.
- When the error modal appears, check if you can download the log files and preview the logs.

<!-- Issues that this pull request closes. -->
Closes #
<!-- Should look like this: `Closes #1, #2, #3.` . -->
