### PR TITLE
Fix logger static property access

### DIFF
--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -219,7 +219,7 @@ class Logger {
 	 * Get the log URL.
 	 */
 	public function get_log_url() {
-		return $this->log_file_path_url . $this->log_transient_name;
+		return $this->log_file_path_url . self::$log_transient_name;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Use the correct syntax for accessing the static var in the logger.

### Test instructions
<!-- Describe how this pull request can be tested. -->

1.  Enable WP_DEBUG
2. Go to the dashboard and try to import something
3. You should not see any notices regarding errors in the logger file. (anything that mentions Logger.php)

<!-- Issues that this pull request closes. -->
Closes #296 
<!-- Should look like this: `Closes #1, #2, #3.` . -->
