### PR TITLE
fix: refactor the component and fix track data

### DIFF
--- a/onboarding/src/Components/CategoryButtons.js
+++ b/onboarding/src/Components/CategoryButtons.js
@@ -1,17 +1,48 @@
 /* global tiobDash */
-import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { track } from '../utils/rest';
 
-const CategoryButtons = ( { category, categories, onClick, style } ) => {
+const CategoryButtons = ( { categories, style } ) => {
+	const data = useSelect( ( select ) => ( {
+		category: select( 'ti-onboarding' ).getCurrentCategory(),
+		query: select( 'ti-onboarding' ).getSearchQuery(),
+		trackingId: select( 'ti-onboarding' ).getTrackingId(),
+		step: select( 'ti-onboarding' ).getCurrentStep(),
+	} ) );
+
+	const { setOnboardingStep, setCategory } = useDispatch( 'ti-onboarding' );
+
+	const onClick = ( newCategory ) => {
+		setCategory( newCategory );
+
+		if ( data.step === 1 ) {
+			setOnboardingStep( 2 );
+
+			const trackData = {
+				slug: 'neve',
+				license_id: tiobDash.license,
+				site: tiobDash.onboarding.homeUrl || '',
+				search: data.query,
+				cat: newCategory,
+				step_id: 1,
+				step_status: 'completed',
+			};
+
+			track( data.trackingId, trackData ).catch( ( error ) => {
+				// eslint-disable-next-line no-console
+				console.error( error );
+			} );
+		}
+	};
+
 	return (
 		<div className="ob-cat-wrap" style={ style }>
 			{ Object.keys( categories ).map( ( key, index ) => {
 				const classes = classnames( {
 					cat: true,
 					[ key ]: true,
-					active: key === category,
+					active: key === data.category,
 				} );
 
 				return (
@@ -28,43 +59,4 @@ const CategoryButtons = ( { category, categories, onClick, style } ) => {
 	);
 };
 
-export default compose(
-	withSelect( ( select ) => {
-		const {
-			getCurrentCategory,
-			getSearchQuery,
-			getTrackingId,
-			getCurrentStep,
-		} = select( 'ti-onboarding' );
-		return {
-			category: getCurrentCategory(),
-			query: getSearchQuery(),
-			trackingId: getTrackingId(),
-			step: getCurrentStep(),
-		};
-	} ),
-	withDispatch( ( dispatch, { query, trackingId, category, step } ) => {
-		const { setOnboardingStep, setCategory } = dispatch( 'ti-onboarding' );
-		return {
-			onClick: ( newCategory ) => {
-				setCategory( newCategory );
-				if ( step === 1 ) {
-					setOnboardingStep( 2 );
-					const data = {
-						slug: 'neve',
-						license_id: tiobDash.license,
-						site: tiobDash.onboarding.homeUrl || '',
-						search: query,
-						cat: category,
-						step_id: 1,
-						step_status: 'completed',
-					};
-					track( trackingId, data ).catch( ( error ) => {
-						// eslint-disable-next-line no-console
-						console.error( error );
-					} );
-				}
-			},
-		};
-	} )
-)( CategoryButtons );
+export default CategoryButtons;

--- a/onboarding/src/Components/ImportError.js
+++ b/onboarding/src/Components/ImportError.js
@@ -1,30 +1,29 @@
 /* global tiobDash */
 import { Dashicon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {useEffect, useState} from "@wordpress/element";
-import {getLogsFromServer} from "../utils/rest";
-import {textToFileURL} from "../utils/common";
+import { useEffect, useState } from '@wordpress/element';
+import { getLogsFromServer } from '../utils/rest';
+import { textToFileURL } from '../utils/common';
 
 const ImportError = ( { message, code } ) => {
+	const [ logs, setLogs ] = useState( {} );
 
-	const [logs, setLogs] = useState( {} );
-
-	useEffect(() => {
-		getLogsFromServer({
-			success: function (response) {
-				setLogs({
+	useEffect( () => {
+		getLogsFromServer( {
+			success( response ) {
+				setLogs( {
 					raw: response,
-					url: textToFileURL(response),
-				});
+					url: textToFileURL( response ),
+				} );
 			},
-		});
+		} );
 
 		return () => {
 			if ( logs?.url ) {
-				URL.revokeObjectURL(logs.url);
+				URL.revokeObjectURL( logs.url );
 			}
-		}
-	}, []);
+		};
+	}, [] );
 
 	return (
 		<div className="ob-error-wrap">
@@ -53,16 +52,20 @@ const ImportError = ( { message, code } ) => {
 				) }
 				<li>
 					{ __( 'Error log', 'templates-patterns-collection' ) }:{ ' ' }
-					<a download={"ti_theme_onboarding.log"} href={logs.url}>
-						{ __( 'Download Logs File', 'templates-patterns-collection' ) }
+					<a download={ 'ti_theme_onboarding.log' } href={ logs.url }>
+						{ __(
+							'Download Logs File',
+							'templates-patterns-collection'
+						) }
 					</a>
 					<details>
 						<summary>
-							{ __( 'See logs', 'templates-patterns-collection' ) }
+							{ __(
+								'See logs',
+								'templates-patterns-collection'
+							) }
 						</summary>
-						<div>
-							{ logs.raw }
-						</div>
+						<div>{ logs.raw }</div>
 					</details>
 				</li>
 			</ul>

--- a/onboarding/src/Components/Search.js
+++ b/onboarding/src/Components/Search.js
@@ -70,7 +70,7 @@ export default compose(
 			trackingId: getTrackingId(),
 		};
 	} ),
-	withDispatch( ( dispatch, { step, query, trackingId, category } ) => {
+	withDispatch( ( dispatch, { step, query, trackingId } ) => {
 		const { setSearchQuery, setCategory, setOnboardingStep } = dispatch(
 			'ti-onboarding'
 		);

--- a/onboarding/src/Components/Search.js
+++ b/onboarding/src/Components/Search.js
@@ -87,7 +87,7 @@ export default compose(
 						license_id: tiobDash.license,
 						site: tiobDash.onboarding.homeUrl || '',
 						search: query,
-						cat: category,
+						cat: 'all',
 						step_id: 1,
 						step_status: 'completed',
 					};

--- a/onboarding/src/Components/SiteSettings.js
+++ b/onboarding/src/Components/SiteSettings.js
@@ -245,7 +245,9 @@ export const SiteSettings = ( {
 									<Button
 										isPrimary
 										className="ob-button full"
-										onClick={ () => identityChoicesSubmit() }
+										onClick={ () =>
+											identityChoicesSubmit()
+										}
 										disabled={
 											fetching ||
 											( ! siteName &&

--- a/onboarding/src/utils/common.js
+++ b/onboarding/src/utils/common.js
@@ -1,3 +1,4 @@
+/* global Blob */
 import { __ } from '@wordpress/i18n';
 
 const untrailingSlashIt = ( str ) => str.replace( /\/$/, '' );
@@ -41,12 +42,12 @@ const sendPostMessage = ( data ) => {
  * Convert text to file URL.
  *
  * @param {string} text - Text to convert
- * @returns {string} - File URL
+ * @return {string} - File URL
  */
 const textToFileURL = ( text ) => {
 	const blob = new Blob( [ text ], { type: 'text/plain' } );
 	return URL.createObjectURL( blob );
-}
+};
 
 export {
 	trailingSlashIt,

--- a/onboarding/src/utils/rest.js
+++ b/onboarding/src/utils/rest.js
@@ -1,4 +1,4 @@
-/* global tiobDash, FormData, fetch */
+/* global tiobDash, FormData, fetch, jQuery, ajaxurl */
 /* eslint-disable no-console */
 
 export const send = ( route, data, simple = false ) => {
@@ -116,16 +116,17 @@ export const track = async ( trackingId = '', data ) => {
 
 /**
  * Get logs from server using ajax.
+ *
  * @param {Object} args - ajax arguments
  */
-export const getLogsFromServer = (args) => {
-	jQuery.ajax({
+export const getLogsFromServer = ( args ) => {
+	jQuery.ajax( {
 		type: 'post',
 		url: ajaxurl,
 		data: {
 			action: 'tpc_get_logs',
 			nonce: tiobDash.nonce,
 		},
-		...args
-	})
-}
+		...args,
+	} );
+};


### PR DESCRIPTION
### Summary
- Improve the readability of CategoryButtons
- Fix the tracking data in the CategoryButtons component to send the selected category, not the one from the state.
- Fix the tracking data in the Search component to send the "all" category on submit and not the category from the state.

### Test instructions
- The changes only targeted the category buttons that are present in the first and second steps and the search input from the first step.  Please make sure they work as they should.
- You can check that the data is sending correctly by checking the Network tab of dev tools: https://vertis.d.pr/v/ZNbE6K
- For the search input, the tracking is happening on submit, just on the first page and when the input is submitted, the category is changed to 'all' automatically.

<!-- Issues that this pull request closes. -->
Closes #301.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
