### PR TITLE
Fix: TPC icon is not visible in the Gutenberg editor with WP 6.4

### DIFF
--- a/editor/src/data/templates-cloud/index.js
+++ b/editor/src/data/templates-cloud/index.js
@@ -6,10 +6,10 @@ import { v4 as uuidv4 } from 'uuid';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
 
-const { omit } = lodash;
-
 const { updateLibrary, updateTemplates } = dispatch( 'tpc/block-editor' );
 const { createNotice } = dispatch( 'core/notices' );
+
+const { meta, ...filteredParams } = tiTpc.params;
 
 const createErrorNotice = ( message ) => {
 	createNotice( 'warning', message, {
@@ -21,7 +21,7 @@ const createErrorNotice = ( message ) => {
 export const fetchTemplates = async ( additionalParams = {} ) => {
 	const params = {
 		cache: localStorage.getItem( 'tpcCacheBuster' ),
-		...omit( tiTpc.params, 'meta' ),
+		...filteredParams,
 		per_page: 12,
 		page: 0,
 		premade: true,
@@ -69,7 +69,7 @@ export const fetchLibrary = async ( additionalParams = {} ) => {
 		url: tiTpc.endpoint + 'templates',
 		query: {
 			cache: localStorage.getItem( 'tpcCacheBuster' ),
-			...omit( tiTpc.params, 'meta' ),
+			...filteredParams,
 			...params,
 		},
 	} );
@@ -105,7 +105,7 @@ export const updateTemplate = async ( params ) => {
 		url: `${ tiTpc.endpoint }templates/${ params.template_id }`,
 		query: {
 			cache: localStorage.getItem( 'tpcCacheBuster' ),
-			...omit( tiTpc.params, 'meta' ),
+			...filteredParams,
 			meta: JSON.stringify( tiTpc.params.meta ),
 			...params,
 		},
@@ -141,7 +141,7 @@ export const getTemplate = async ( template ) => {
 		url: `${ window.tiTpc.endpoint }templates/${ template }`,
 		query: {
 			cache: localStorage.getItem( 'tpcCacheBuster' ),
-			...omit( tiTpc.params, 'meta' ),
+			...filteredParams,
 		},
 	} );
 
@@ -171,7 +171,7 @@ export const importTemplate = async ( template ) => {
 		url: `${ tiTpc.endpoint }templates/${ template }/import`,
 		query: {
 			cache: localStorage.getItem( 'tpcCacheBuster' ),
-			...omit( tiTpc.params, 'meta' ),
+			...filteredParams,
 		},
 	} );
 
@@ -205,7 +205,7 @@ export const duplicateTemplate = async ( template ) => {
 		url: `${ tiTpc.endpoint }templates/${ template }/clone`,
 		query: {
 			cache: localStorage.getItem( 'tpcCacheBuster' ),
-			...omit( tiTpc.params, 'meta' ),
+			...filteredParams,
 		},
 	} );
 
@@ -241,7 +241,7 @@ export const deleteTemplate = async ( template, sortingOrder ) => {
 		query: {
 			cache: localStorage.getItem( 'tpcCacheBuster' ),
 			_method: 'DELETE',
-			...omit( tiTpc.params, 'meta' ),
+			...filteredParams,
 		},
 	} );
 
@@ -282,7 +282,7 @@ export const publishTemplate = async (
 			template_thumbnail: featuredImageURL,
 			premade: publishStatus ? 'yes' : 'no',
 			link,
-			...omit( tiTpc.params, 'meta' ),
+			...filteredParams,
 		},
 	} );
 

--- a/editor/src/edit.js
+++ b/editor/src/edit.js
@@ -18,8 +18,6 @@ import Content from './components/content';
 import PreviewFrame from '../../assets/src/Components/CloudLibrary/PreviewFrame';
 import { importTemplate } from './data/templates-cloud';
 
-const { omit } = lodash;
-
 const Edit = ( {
 	clientId,
 	isPreview,
@@ -133,8 +131,9 @@ const Edit = ( {
 			allowed_post.includes( type )
 		) {
 			const fields = JSON.parse( metaFields );
+			const { _wp_page_template, ...filteredFields } = { ...fields };
 			const meta = {
-				...omit( { ...fields }, '_wp_page_template' ),
+				...filteredFields,
 			};
 			editPost( { meta } );
 

--- a/editor/src/extension.js
+++ b/editor/src/extension.js
@@ -27,8 +27,6 @@ import { iconBlack } from './icon';
 import { getTemplate, publishTemplate } from './data/templates-cloud';
 import Notices from './components/notices';
 
-const { omit } = lodash;
-
 const Exporter = () => {
 	const [ isOpen, setOpen ] = useState( false );
 	const [ isLoading, setLoading ] = useState( false );
@@ -182,10 +180,15 @@ const Exporter = () => {
 			content,
 		};
 
+		const { meta, ...filteredParams } = window.tiTpc.params;
+		console.log( { meta, filteredParams } );
+		console.log( tiTpc.params );
+		return;
+
 		const url = stringifyUrl( {
 			url: window.tiTpc.endpoint + 'templates',
 			query: {
-				...omit( tiTpc.params, 'meta' ),
+				...filteredParams,
 				template_name: title,
 				template_type: 'gutenberg',
 			},
@@ -255,7 +258,7 @@ const Exporter = () => {
 			return;
 		}
 
-		let meta = tiTpc.params.meta;
+		let { meta, ...filteredParams } = window.tiTpc.params;
 		// For Custom Layouts attach additional meta to check on import.
 		if ( type === 'neve_custom_layouts' ) {
 			meta = { ...tiTpc.params.meta, postType: type };
@@ -264,7 +267,7 @@ const Exporter = () => {
 			url = stringifyUrl( {
 				url: window.tiTpc.endpoint + 'templates',
 				query: {
-					...omit( tiTpc.params, 'meta' ),
+					...filteredParams,
 					meta: JSON.stringify( meta ),
 					template_name: postTitle,
 					template_type: 'gutenberg',
@@ -277,7 +280,7 @@ const Exporter = () => {
 			url = stringifyUrl( {
 				url: window.tiTpc.endpoint + 'templates/' + templateID,
 				query: {
-					...omit( tiTpc.params, 'meta' ),
+					...filteredParams,
 					meta: JSON.stringify( meta ),
 					template_name: postTitle,
 					link,

--- a/editor/src/extension.js
+++ b/editor/src/extension.js
@@ -181,9 +181,6 @@ const Exporter = () => {
 		};
 
 		const { meta, ...filteredParams } = window.tiTpc.params;
-		console.log( { meta, filteredParams } );
-		console.log( tiTpc.params );
-		return;
 
 		const url = stringifyUrl( {
 			url: window.tiTpc.endpoint + 'templates',

--- a/elementor/src/template-library.js
+++ b/elementor/src/template-library.js
@@ -9,8 +9,6 @@ import Content from './components/content.js';
 import { importTemplate } from './data/templates-cloud/index.js';
 import { setPostModel } from './data/utils';
 
-const { omit } = lodash;
-
 const TemplateLibrary = ( { currentTab, setFetching } ) => {
 	const [ searchQuery, setSearchQuery ] = useState( {
 		templates: '',
@@ -164,9 +162,10 @@ const TemplateLibrary = ( { currentTab, setFetching } ) => {
 			0 < Object.keys( tryParseJSON( meta ) || {} ).length
 		) {
 			meta = { ...JSON.parse( meta ) };
+			const { _wp_page_template, ...filteredFields } = meta;
 
 			window.tiTpc.postModel.set( 'meta', {
-				...omit( meta, '_wp_page_template' ),
+				...filteredFields,
 			} );
 			window.tiTpc.postModel.save();
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Removed the `omit` requirement that was used from `lodash` and replaced it with a native spread operation instead.

Notes:
`lodash` was used from Neve and never packaged as part of this plugin, previously it would default to using the `lodash` from WP, but was removed for the newer versions of WordPress.
Since we only use the `omit` function, I think it can be safely removed and replaced with a native function already available in JS.

### Test instructions
<!-- Describe how this pull request can be tested. -->
<details open>
    <summary><h4>Testing with WP 6.4</h4></summary>

1. Install WordPress 6.4 RC2 using [WordPress Beta Release](https://wordpress.org/plugins/wordpress-beta-tester/)
2. Install TPC only (without Neve), and **Activate it** using a valid key.
3. Open the editor and check if the TPC icon is visible
    ![image](https://github.com/Codeinwp/templates-patterns-collection/assets/23024731/db454aca-ed92-49d2-aa17-5e0827bac165)
4. Check that it works as before when Neve is enabled.
</details>

<details>
    <summary><h4>Testing with WP 6.3.2 or current version</h4></summary>

1. Install TPC only (without Neve), and **Activate it** using a valid key.
2. Open the editor and check if the TPC icon is visible the same as on the previous test.
3. Check that it works as before when Neve is enabled.
</details>

<!-- Issues that this pull request closes. -->
Closes #309.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
