### PR TITLE
Fix typo in onboarding

### DIFF
--- a/onboarding/src/Components/Steps/Import.js
+++ b/onboarding/src/Components/Steps/Import.js
@@ -321,7 +321,7 @@ const Import = ( {
 						</h1>
 						<p>
 							{ __(
-								'Sit tight as we import a website based on your references.',
+								'Sit tight as we import a website based on your preferences.',
 								'templates-patterns-collection'
 							) }
 						</p>


### PR DESCRIPTION
### Summary
- Fix a small typo in the importing step

### Test instructions
- Import a starter site using the new onboarding
- Check to see if the typo is fixed in the importing step


<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve#4127.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
