### PR TITLE
Adds S in the Template Cloud Tab admin name and minor style changes

### DIFF
--- a/assets/src/Components/Settings/Settings.js
+++ b/assets/src/Components/Settings/Settings.js
@@ -86,7 +86,7 @@ const Feedback = () => {
                     'feedback_details': true,
                     'invalid': 'emptyFeedback' === feedbackStatus,
                 }) }
-                placeholder={ __( 'Tell us how can we help you better with Template Cloud', 'template-patterns-collection' ) }
+                placeholder={ __( 'Tell us how can we help you better with Templates Cloud', 'template-patterns-collection' ) }
                 value={ feedbackDetails }
                 help={ feedbackStatusText[feedbackStatus] || false }
                 rows={7}

--- a/assets/src/scss/_feedback.scss
+++ b/assets/src/scss/_feedback.scss
@@ -36,12 +36,12 @@
 
 .tiob-feedback-form {
   margin-top: 24px;
-  padding: 24px;
-  border: 1px solid #eaeaea;
+  padding: 0px;
+  border: 0;
 }
 
 .tiob_feedback_modal, .tiob-feedback-form {
-  max-width: 500px;
+  max-width: 100%;
   border-radius: 4px;
   .components-modal__header {
     background-color: var(--wp-admin-theme-color);
@@ -70,6 +70,9 @@
     }
     &.invalid p {
       color: red;
+    }
+    &.submitted p {
+      color: green;
     }
   }
 }

--- a/assets/src/scss/_settings.scss
+++ b/assets/src/scss/_settings.scss
@@ -56,6 +56,7 @@
     border: 0;
     box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.1);
     background: none;
+    padding: 24px 0px;
 
     .license-form {
       display: flex;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -428,8 +428,8 @@ class Admin {
 		$plugin_page = 'tiob-plugin';
 
 		$tpc_menu_page_data = array(
-			'page_title' => __( 'Template Cloud', 'templates-patterns-collection' ),
-			'menu_title' => __( 'Template Cloud', 'templates-patterns-collection' ),
+			'page_title' => __( 'Templates Cloud', 'templates-patterns-collection' ),
+			'menu_title' => __( 'Templates Cloud', 'templates-patterns-collection' ),
 			'capability' => 'manage_options',
 			'menu_slug'  => $plugin_page,
 			'callback'   => array(


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
We reference everywhere the product as Template**s** Cloud, but in the WP Admin tab it is **Template.**
So I added the S:
![Screenshot 2024-02-15 at 17 58 22](https://github.com/Codeinwp/templates-patterns-collection/assets/52494172/6c1fdc2d-2326-47c1-a23d-ceb65bafebdc)

___
And also change the Padding a bit on the Settings page, to make it be more aligned with the UI in general + the Feedback form:

![Screenshot 2024-02-15 at 17 59 11](https://github.com/Codeinwp/templates-patterns-collection/assets/52494172/c933c4e6-d92f-4e04-a0ef-9e0763134ee2)

![Screenshot 2024-02-15 at 17 59 27](https://github.com/Codeinwp/templates-patterns-collection/assets/52494172/f9bc916c-45f9-46df-a916-1e3b52d5e93f)



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install TPC from the build
- in the WP Admin now it should say Template**s** instead of Template
- the padding on the Settings page should look more uniform
- and the Feedback form should take the full width of the container.

