### PR TITLE
fix: changed upsell message

### DIFF
--- a/onboarding/src/Components/SiteSettings.js
+++ b/onboarding/src/Components/SiteSettings.js
@@ -53,7 +53,7 @@ export const SiteSettings = ( {
 			'templates-patterns-collection'
 		);
 		description = __(
-			'Upgrade to Neve Pro to enjoy unlimited access to all templates in the library.',
+			'Upgrade to Neve Business plan to enjoy unlimited access to all templates in the library.',
 			'templates-patterns-collection'
 		);
 	}

--- a/onboarding/src/Components/Steps/SiteList.js
+++ b/onboarding/src/Components/Steps/SiteList.js
@@ -11,7 +11,7 @@ import SVG from '../../utils/svg';
 const SiteList = ( { showToast, setShowToast, setFetching } ) => {
 	const toastMessage = createInterpolateElement(
 		__(
-			'Unlock Access to all premium templates with Neve PRO. <a></a>.',
+			'Unlock Access to all premium templates with Neve Business plan. <a></a>.',
 			'templates-patterns-collection'
 		),
 		{


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Updated the upsell message for the Starter Site Onboarding.
These changes also work well with this PR: https://github.com/Codeinwp/themeisle/pull/1628 for conditional displaying pricing.

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check the upsell mesages
2. Check that on themeisle staging the following URL format will only display 2 items inside the pricing table: https://fmbklha76y-staging.onrocket.site/themes/neve/upgrade/?utm_source=wpadmin&utm_medium=admin&utm_campaign=onboarding_upsell&utm_content=neve#pricing

<!-- Issues that this pull request closes. -->
Closes #330.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
