### PR TITLE
fix: plugin sidebar import

### DIFF
--- a/bin/e2e-env.sh
+++ b/bin/e2e-env.sh
@@ -34,6 +34,12 @@ init_environment(){
     # Install dependent plugins
     docker-compose -f $DOCKER_FILE run --rm -u root cli wp --allow-root plugin install --force --activate otter-blocks
     docker-compose -f $DOCKER_FILE run --rm -u root cli wp --allow-root plugin install --force --activate optimole-wp
+
+    # Disable Neve Onboarding
+    docker-compose -f $DOCKER_FILE run --rm -u root cli wp --allow-root config set TI_ONBOARDING_DISABLED true --raw
+
+    # Disable Otter Onboarding
+    docker-compose -f $DOCKER_FILE run --rm -u root cli wp --allow-root config set ENABLE_OTTER_PRO_DEV true --raw
 }
 
 docker-compose -f $DOCKER_FILE run --rm -u root wordpress mkdir -p /var/www/html/wp-content/uploads

--- a/e2e-tests/cypress/e2e/editor.spec.ts
+++ b/e2e-tests/cypress/e2e/editor.spec.ts
@@ -5,20 +5,20 @@ describe( 'Gutenberg Editor', () => {
     });
 
     it( 'Add a navigation block', () => {
-        cy.window().then( win => {
-            const navBlock = win.wp.blocks.createBlock( 'core/navigation' );
-            win.wp.data.dispatch( 'core/block-editor' ).insertBlocks( navBlock );
-        } );
-
         cy.intercept({
             method: 'OPTIONS',
             url: '/wp-json/wp/v2/navigation/**'
         }).as('getNavigation');
 
-        cy.wait('@getNavigation') // Wait for navigation to pull its data.
-        .then(() => {
-            // We should have no rendering warning.
-            cy.get('.block-editor-warning__message').should('not.exist');
-        });
+        cy.window().then( win => {
+            const navBlock = win.wp.blocks.createBlock( 'core/navigation' );
+            win.wp.data.dispatch( 'core/block-editor' ).insertBlocks( navBlock ).then(() => {
+                cy.wait('@getNavigation') // Wait for navigation to pull its data.
+                .then(() => {
+                    // We should have no rendering warning.
+                    cy.get('.block-editor-warning__message').should('not.exist');
+                });
+            })
+        } );
     } );
 });

--- a/e2e-tests/cypress/e2e/editor.spec.ts
+++ b/e2e-tests/cypress/e2e/editor.spec.ts
@@ -1,0 +1,24 @@
+describe( 'Gutenberg Editor', () => {
+    beforeEach(() => {
+        cy.visit('/');
+        cy.visit('/wp-admin/post-new.php');
+    });
+
+    it( 'Add a navigation block', () => {
+        cy.window().then( win => {
+            const navBlock = win.wp.blocks.createBlock( 'core/navigation' );
+            win.wp.data.dispatch( 'core/block-editor' ).insertBlocks( navBlock );
+        } );
+
+        cy.intercept({
+            method: 'OPTIONS',
+            url: '/wp-json/wp/v2/navigation/**'
+        }).as('getNavigation');
+
+        cy.wait('@getNavigation') // Wait for navigation to pull its data.
+        .then(() => {
+            // We should have no rendering warning.
+            cy.get('.block-editor-warning__message').should('not.exist');
+        });
+    } );
+});

--- a/editor/src/plugins/site-editor-extension.js
+++ b/editor/src/plugins/site-editor-extension.js
@@ -10,7 +10,7 @@ import {
 	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-site';
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import api from '@wordpress/api';


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Fix the name of the import package for plugin sidebar dependencies in Editor.

> [!NOTE]
> Gutenberg teams have started the deprecation for the next version: https://github.com/WordPress/gutenberg/commit/bd8c9a73ab5082f1fcfdb72e407247a8250a7892

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/templates-patterns-collection/assets/17597852/50a5f62c-4d45-4fd8-8af6-3ca11f277807

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a new post.
- Insert a Navigation block.
- No block crash should happen. 

## Check before Pull Request is ready:

* [X] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [X] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [X] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [X] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [X] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/templates-patterns-collection/issues/359
<!-- Should look like this: `Closes #1, #2, #3.` . -->
