### PR TITLE
Fixed starter sites loading error

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v1
         with:
-          php-version: '7.1'
+          php-version: '7.4'
           extensions: simplexml
           tools: composer:v2.1
       - name: Checkout source code
@@ -52,7 +52,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: '7.4'
           extensions: simplexml, mysql
           tools: phpunit-polyfills
       - name: Checkout source code

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -634,7 +634,7 @@ class Admin {
 			wp_style_add_data( 'tiobObd', 'rtl', 'replace' );
 			wp_enqueue_style( 'tiobObd' );
 
-			wp_register_script( 'tiobObd', TIOB_URL . 'onboarding/build/index.js', array_merge( $onboarding_dependencies['dependencies'], array( 'updates' ) ), $onboarding_dependencies['version'], true );
+			wp_register_script( 'tiobObd', TIOB_URL . 'onboarding/build/index.js', array_merge( $onboarding_dependencies['dependencies'], array( 'updates', 'regenerator-runtime' ) ), $onboarding_dependencies['version'], true );
 			wp_localize_script( 'tiobObd', 'tiobDash', apply_filters( 'neve_dashboard_page_data', $this->get_localization() ) );
 			wp_enqueue_script( 'tiobObd' );
 
@@ -667,7 +667,7 @@ class Admin {
 		wp_style_add_data( 'tiob', 'rtl', 'replace' );
 		wp_enqueue_style( 'tiob' );
 
-		wp_register_script( 'tiob', TIOB_URL . 'assets/build/app.js', array_merge( $dependencies['dependencies'], array( 'updates' ) ), $dependencies['version'], true );
+		wp_register_script( 'tiob', TIOB_URL . 'assets/build/app.js', array_merge( $dependencies['dependencies'], array( 'updates', 'regenerator-runtime' ) ), $dependencies['version'], true );
 		$tiob_dash = apply_filters( 'neve_dashboard_page_data', $this->get_localization() );
 		if ( $is_tiob_page ) {
 			$tiob_dash['hideStarterSites'] = true;

--- a/includes/Editor.php
+++ b/includes/Editor.php
@@ -71,7 +71,7 @@ class Editor {
 		wp_register_script(
 			$this->handle,
 			TIOB_URL . 'editor/build/index.js',
-			array_merge( $deps['dependencies'], array( 'wp-api' ) ),
+			array_merge( $deps['dependencies'], array( 'wp-api', 'regenerator-runtime' ) ),
 			$deps['version']
 		);
 

--- a/tests/digital-test.php
+++ b/tests/digital-test.php
@@ -41,7 +41,7 @@ class Digital_Rest_Test extends WP_UnitTestCase {
 	/**
 	 * setUp
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		wp_set_current_user( self::$admin_id );
 		add_theme_support(

--- a/tests/import-test.php
+++ b/tests/import-test.php
@@ -14,7 +14,7 @@ use TIOB\Importers\WP\WP_Import;
  */
 class Import_Test extends WP_UnitTestCase {
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		register_taxonomy(
 			'product_type',

--- a/tests/rest-test.php
+++ b/tests/rest-test.php
@@ -40,7 +40,7 @@ class Onboarding_Rest_Test extends WP_UnitTestCase {
 	/**
 	 * setUp
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		wp_set_current_user( self::$admin_id );
 		add_theme_support( 'themeisle-demo-import', [


### PR DESCRIPTION
### Summary
I've fixed the starter site loading issue with WP 6.6

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/neve-pro-addon/issues/2833
