### PR TITLE
feat: add support for WPFS imports

### DIFF
--- a/assets/src/Components/ImportModal.js
+++ b/assets/src/Components/ImportModal.js
@@ -583,6 +583,7 @@ const ImportModal = ( {
 			source: 'remote',
 			frontPage: importData.front_page,
 			shopPages: importData.shop_pages,
+			paymentForms: importData.payment_forms,
 			demoSlug: importData.slug,
 			editor,
 		} )

--- a/includes/Importers/Cleanup/Active_State.php
+++ b/includes/Importers/Cleanup/Active_State.php
@@ -14,20 +14,21 @@ namespace TIOB\Importers\Cleanup;
  */
 class Active_State {
 
-	const STATE_NAME      = 'neve_last_imports';
-	const HOUR_IN_SECONDS = 3600;
-	const PLUGINS_NSP     = 'plugins';
-	const CATEGORY_NSP    = 'category';
-	const TAGS_NSP        = 'tags';
-	const TERMS_NSP       = 'terms';
-	const POSTS_NSP       = 'posts';
-	const COMMENTS_NSP    = 'comments';
-	const ATTACHMENT_NSP  = 'attachment';
-	const FRONT_PAGE_NSP  = 'front_page_options';
-	const SHOP_PAGE_NSP   = 'shop_page_options';
-	const THEME_MODS_NSP  = 'theme_mods';
-	const MENUS_NSP       = 'menus';
-	const WIDGETS_NSP     = 'widgets';
+	const STATE_NAME       = 'neve_last_imports';
+	const HOUR_IN_SECONDS  = 3600;
+	const PLUGINS_NSP      = 'plugins';
+	const CATEGORY_NSP     = 'category';
+	const TAGS_NSP         = 'tags';
+	const TERMS_NSP        = 'terms';
+	const POSTS_NSP        = 'posts';
+	const COMMENTS_NSP     = 'comments';
+	const ATTACHMENT_NSP   = 'attachment';
+	const FRONT_PAGE_NSP   = 'front_page_options';
+	const SHOP_PAGE_NSP    = 'shop_page_options';
+	const PAYMENT_FORM_NSP = 'payment_form_options';
+	const THEME_MODS_NSP   = 'theme_mods';
+	const MENUS_NSP        = 'menus';
+	const WIDGETS_NSP      = 'widgets';
 	/**
 	 * @var array $state
 	 */
@@ -64,6 +65,7 @@ class Active_State {
 				self::WIDGETS_NSP,
 				self::FRONT_PAGE_NSP,
 				self::SHOP_PAGE_NSP,
+				self::PAYMENT_FORM_NSP,
 			),
 			true
 		);

--- a/includes/Importers/Cleanup/Manager.php
+++ b/includes/Importers/Cleanup/Manager.php
@@ -288,7 +288,7 @@ class Manager {
 		$this->cleanup_terms( $state );
 		$this->cleanup_options( Active_State::FRONT_PAGE_NSP, $state );
 		$this->cleanup_options( Active_State::SHOP_PAGE_NSP, $state );
-		$this->cleanup_forms( ACTIVE_STATE::PAYMENT_FORM_NSP, $state );
+		$this->cleanup_forms( Active_State::PAYMENT_FORM_NSP, $state );
 		$this->cleanup_posts( $state );
 		$this->cleanup_attachments( $state );
 		$this->cleanup_widgets( $state );

--- a/includes/Importers/Cleanup/Manager.php
+++ b/includes/Importers/Cleanup/Manager.php
@@ -255,7 +255,7 @@ class Manager {
 			foreach ( $state[ $namespace ] as $name => $form ) {
 				$get    = 'get' . ucfirst( $form['layout'] ) . ucfirst( $form['type'] ) . 'FormByName';
 				$method = 'delete' . ucfirst( $form['layout'] ) . ucfirst( $form['type'] ) . 'Form';
-				$id	    = null;
+				$id     = null;
 
 				if ( method_exists( 'MM_WPFS_Database', $get ) ) {
 					$item = $db->$get( $name );

--- a/includes/Importers/Cleanup/Manager.php
+++ b/includes/Importers/Cleanup/Manager.php
@@ -240,6 +240,44 @@ class Manager {
 		}
 	}
 
+	/**
+	 * Handles form cleanup.
+	 * @param array $state The cleanup state.
+	 */
+	private function cleanup_forms( $namespace, $state ) {
+		if ( ! class_exists( 'MM_WPFS_Database' ) ) {
+			return;
+		}
+
+		$db = new \MM_WPFS_Database();
+
+		if ( isset( $state[ $namespace ] ) ) {
+			foreach ( $state[ $namespace ] as $name => $form ) {
+				$get    = 'get' . ucfirst( $form['layout'] ) . ucfirst( $form['type'] ) . 'FormByName';
+				$method = 'delete' . ucfirst( $form['layout'] ) . ucfirst( $form['type'] ) . 'Form';
+				$id	    = null;
+
+				if ( method_exists( 'MM_WPFS_Database', $get ) ) {
+					$item = $db->$get( $name );
+					foreach ( $item as $key => $value ) {
+						if ( strpos( $key, 'FormID' ) !== false ) {
+							$id = $value;
+							break;
+						}
+					}
+				}
+
+				if ( empty( $id ) ) {
+					continue;
+				}
+
+				if ( method_exists( 'MM_WPFS_Database', $method ) ) {
+					$db->$method( $id );
+				}
+			}
+		}
+	}
+
 	final public function do_cleanup() {
 		$active_state = new Active_State();
 		$state        = $active_state->get();
@@ -250,6 +288,7 @@ class Manager {
 		$this->cleanup_terms( $state );
 		$this->cleanup_options( Active_State::FRONT_PAGE_NSP, $state );
 		$this->cleanup_options( Active_State::SHOP_PAGE_NSP, $state );
+		$this->cleanup_forms( ACTIVE_STATE::PAYMENT_FORM_NSP, $state );
 		$this->cleanup_posts( $state );
 		$this->cleanup_attachments( $state );
 		$this->cleanup_widgets( $state );

--- a/includes/Importers/Plugin_Importer.php
+++ b/includes/Importers/Plugin_Importer.php
@@ -53,6 +53,7 @@ class Plugin_Importer {
 		'recipe-card-blocks-by-wpzoom'     => 'wpzoom-recipe-card.php',
 		'restrict-content'                 => 'restrictcontent.php',
 		'pods'                             => 'init.php',
+		'wp-full-stripe-free'              => 'wp-full-stripe.php',
 	);
 
 	public function __construct() {

--- a/onboarding/src/Components/Steps/Import.js
+++ b/onboarding/src/Components/Steps/Import.js
@@ -160,6 +160,7 @@ const Import = ( {
 			source: 'remote',
 			frontPage: importData.front_page,
 			shopPages: importData.shop_pages,
+			paymentForms: importData.payment_forms,
 			demoSlug: importData.slug,
 			editor,
 		} )


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This adds support for importing WP Full Stripe payment forms to Starter Site Importer.

This PR also moves Non Profit Gutenberg template to being a free website and to position #6.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check here: https://github.com/Codeinwp/demo-data-exporter/pull/225

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1693.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
