### PR TITLE
Change Onboarding categories and search experience

### DIFF
--- a/onboarding/src/Components/CategoryButtons.js
+++ b/onboarding/src/Components/CategoryButtons.js
@@ -2,6 +2,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { track } from '../utils/rest';
+import { useMemo } from '@wordpress/element';
 
 const CategoryButtons = ( { categories, style } ) => {
 	const data = useSelect( ( select ) => ( {
@@ -12,6 +13,13 @@ const CategoryButtons = ( { categories, style } ) => {
 	} ) );
 
 	const { setOnboardingStep, setCategory } = useDispatch( 'ti-onboarding' );
+
+	// Show "All" and "Free" categories after user selection.
+	const availableCategories = useMemo(() => {
+		return Object.keys(categories).filter((key) => 
+			data.category || (key !== 'all' && key !== 'free')
+		);
+	}, [categories, data.category]);
 
 	const onClick = ( newCategory ) => {
 		setCategory( newCategory );
@@ -38,20 +46,20 @@ const CategoryButtons = ( { categories, style } ) => {
 
 	return (
 		<div className="ob-cat-wrap" style={ style }>
-			{ Object.keys( categories ).map( ( key, index ) => {
+			{ availableCategories.map( ( catSlug ) => {
 				const classes = classnames( {
 					cat: true,
-					[ key ]: true,
-					active: key === data.category,
+					[ catSlug ]: true,
+					active: catSlug === data.category,
 				} );
 
 				return (
 					<button
 						className={ classes }
-						key={ index }
-						onClick={ () => onClick( key ) }
+						key={ catSlug }
+						onClick={ () => onClick( catSlug ) }
 					>
-						{ categories[ key ] }
+						{ categories[ catSlug ] }
 					</button>
 				);
 			} ) }

--- a/onboarding/src/Components/Filters.js
+++ b/onboarding/src/Components/Filters.js
@@ -6,6 +6,7 @@ import { ONBOARDING_CAT } from '../utils/common';
 const Filters = () => {
 	const categories = {
 		all: __( 'All', 'templates-patterns-collection' ),
+		free: __( 'Free', 'templates-patterns-collection' ),
 		...ONBOARDING_CAT,
 	};
 

--- a/onboarding/src/Components/Search.js
+++ b/onboarding/src/Components/Search.js
@@ -78,7 +78,6 @@ export default compose(
 			deleteQuery: () => setSearchQuery( '' ),
 			handleSubmit: ( e ) => {
 				e.preventDefault();
-				setCategory( 'all' );
 				if ( step === 1 ) {
 					setOnboardingStep( 2 );
 					const data = {

--- a/onboarding/src/Components/Sites.js
+++ b/onboarding/src/Components/Sites.js
@@ -50,7 +50,7 @@ const Sites = ( { getSites, editor, category, searchQuery } ) => {
 			return items.filter( ( item ) => ! item.upsell );
 		}
 
-		if ( 'all' !== cat ) {
+		if ( cat && 'all' !== cat ) {
 			return items.filter( ( item ) => item.keywords.includes( cat ) );
 		}
 

--- a/onboarding/src/Components/Sites.js
+++ b/onboarding/src/Components/Sites.js
@@ -5,6 +5,8 @@ import StarterSiteCard from './StarterSiteCard';
 import VizSensor from 'react-visibility-sensor';
 import Fuse from 'fuse.js/dist/fuse.min';
 
+const MINIMUM_SITES_LISTING = 10;
+
 const Sites = ( { getSites, editor, category, searchQuery } ) => {
 	const [ maxShown, setMaxShown ] = useState( 9 );
 	const { sites = {} } = getSites;
@@ -14,10 +16,42 @@ const Sites = ( { getSites, editor, category, searchQuery } ) => {
 		if ( Object.keys( allSites ).length === 0 ) {
 			return [];
 		}
-		let builderSites = allSites[ editor ];
-		builderSites = filterBySearch( builderSites );
-		builderSites = filterByCategory( builderSites, category );
 
+		/** @type {Array} */
+		let builderSites = allSites[ editor ];
+		const sitesBySearch = filterBySearch( builderSites );
+		builderSites = filterByCategory( sitesBySearch, category );
+
+		if ( MINIMUM_SITES_LISTING > builderSites.length ) {
+			// Populate with sites related to search.
+			for (const site of sitesBySearch) {
+				if (builderSites.length >= MINIMUM_SITES_LISTING) {
+					break;
+				}
+				if (builderSites.find(existing => existing.slug === site.slug)) {
+					continue;
+				}
+				if (site?.upsell && 'free' === category) {
+					continue;
+				}
+				builderSites.push(site);
+			}
+			
+			// Get the top recommendation if we still do not meed the minimum.
+			for (const site of allSites[editor]) {
+				if (builderSites.length >= MINIMUM_SITES_LISTING) {
+					break;
+				}
+				if (builderSites.find(existing => existing.slug === site.slug)) {
+					continue;
+				}
+				if (site?.upsell && 'free' === category) {
+					continue;
+				}
+				builderSites.push(site);
+			}
+		}
+		
 		return builderSites;
 	};
 

--- a/onboarding/src/scss/_general.scss
+++ b/onboarding/src/scss/_general.scss
@@ -201,7 +201,7 @@ input.components-text-control__input[type="email"],
 @mixin ob-general--laptop() {
   .ob-sites {
     &.is-grid {
-      grid-template-columns: repeat( auto-fit, minmax(346px, 1fr) );
+      grid-template-columns: repeat( auto-fit, 400px);
     }
   }
 }

--- a/onboarding/src/store/reducer.js
+++ b/onboarding/src/store/reducer.js
@@ -19,7 +19,7 @@ const initialLicense = licenseTIOB || {
 const initialState = {
 	sites: onboarding.sites || {},
 	editor: selectedEditor,
-	category: 'all',
+	category: '',
 	currentSite: null,
 	fetching: false,
 	searchQuery: '',

--- a/onboarding/src/utils/common.js
+++ b/onboarding/src/utils/common.js
@@ -5,10 +5,11 @@ const trailingSlashIt = ( str ) => untrailingSlashIt( str ) + '/';
 
 const ONBOARDING_CAT = {
 	business: __( 'Business', 'templates-patterns-collection' ),
-	personal: __( 'Personal', 'templates-patterns-collection' ),
-	blog: __( 'Blogging', 'templates-patterns-collection' ),
-	portfolio: __( 'Portfolio', 'templates-patterns-collection' ),
-	woocommerce: __( 'E-Shop', 'templates-patterns-collection' ),
+	education: __( 'Education', 'templates-patterns-collection' ),
+	woocommerce: __( 'eCommerce', 'templates-patterns-collection' ),
+	news: __( 'News', 'templates-patterns-collection' ),
+	nonprofit: __( 'Non-Profit', 'templates-patterns-collection' ),
+	health: __( 'Health', 'templates-patterns-collection' ),
 };
 
 const EDITOR_MAP = {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Change the list of categories and add conditions to their availability.
- Added a minimum of display of 10 sites on search (user input or/and category) [discussed on Slack]

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES
### Screenshots <!-- if applicable -->
<img width="2187" alt="Screenshot 2024-12-19 at 13 10 57" src="https://github.com/user-attachments/assets/f41ec722-aac6-432c-b0aa-2b04ed8c0a10" />

#### Without a category selected first by the user.
<img width="2182" alt="Screenshot 2024-12-19 at 13 11 28" src="https://github.com/user-attachments/assets/e64fc05b-4c11-40d6-83ea-59bfc5011cdc" />

#### After a user selects a category.

<img width="2175" alt="Screenshot 2024-12-19 at 13 11 35" src="https://github.com/user-attachments/assets/1b6e3215-e7e0-4243-90cc-b81f1e54ea2b" />

----

### Also fixed an issue when the preview goes bigger when there are few options:

#### Before

![image](https://github.com/user-attachments/assets/b1728898-9047-44da-90eb-9102a3e4f288)


#### After

![image](https://github.com/user-attachments/assets/ba61465f-92e6-48e7-8742-a87804a03569)

### Search with minimum sites listing

https://github.com/user-attachments/assets/b40fbd00-e55e-49aa-b767-211ba9e2274c

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check if the new categories are working.
- Check if `Free` and `All` appear after a user selects a category.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2908
<!-- Should look like this: `Closes #1, #2, #3.` . -->
