### PR TITLE
refactor: use only the onboarding workflow to selecting a starter site

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -397,7 +397,15 @@ class Admin {
 		}
 
 		delete_option( 'tpc_maybe_run_onboarding' );
-		wp_safe_redirect( admin_url( 'admin.php?page=neve-onboarding' ) );
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page' => 'neve-onboarding',
+					'show' => 'welcome',
+				),
+				admin_url( 'admin.php' )
+			)
+		);
 		exit();
 	}
 
@@ -620,18 +628,6 @@ class Admin {
 	}
 
 	/**
-	 * Hide the onboarding item from Neve menu.
-	 *
-	 * @param $submenu_file string The submenu file.
-	 *
-	 * @return string
-	 */
-	public function hide_onboarding( $submenu_file ) {
-		remove_submenu_page( 'neve-welcome', 'neve-onboarding' );
-		return $submenu_file;
-	}
-
-	/**
 	 * Map license plan from Neve if available.
 	 *
 	 * @return int
@@ -710,7 +706,7 @@ class Admin {
 			return;
 		}
 
-		if ( $this->should_load_onboarding() && strpos( $screen->id, '_page_neve-onboarding' ) ) {
+		if ( strpos( $screen->id, '_page_neve-onboarding' ) ) {
 
 			wp_enqueue_media();
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -72,7 +72,6 @@ class Admin {
 		add_action( 'after_switch_theme', array( $this, 'get_previous_theme' ) );
 		add_filter( 'neve_dashboard_page_data', array( $this, 'localize_sites_library' ) );
 		add_action( 'admin_menu', array( $this, 'register' ) );
-		add_filter( 'submenu_file', array( $this, 'hide_onboarding' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
 		add_filter( 'ti_tpc_editor_data', array( $this, 'add_tpc_editor_data' ), 20 );
 		add_action( 'admin_init', array( $this, 'activation_redirect' ) );
@@ -514,10 +513,6 @@ class Admin {
 		}
 
 		$this->register_starter_sites_page();
-
-		if ( $this->should_load_onboarding() ) {
-			$this->register_onboarding_page();
-		}
 	}
 
 	private function register_starter_sites_page( $in_appearance = false ) {
@@ -528,12 +523,12 @@ class Admin {
 
 		$starter_site_data = array(
 			'page_title' => __( 'Starter Sites', 'templates-patterns-collection' ),
-			'menu_title' => $this->get_prefix_for_menu_item() . __( 'Starter Sites', 'templates-patterns-collection' ),
-			'capability' => 'activate_plugins',
-			'menu_slug'  => $this->page_slug,
+			'menu_title' => $this->get_prefix_for_menu_item() . __( 'Onboarding', 'templates-patterns-collection' ),
+			'capability' => 'install_plugins',
+			'menu_slug'  => 'neve-onboarding',
 			'callback'   => array(
 				$this,
-				'render_starter_sites',
+				'render_onboarding',
 			),
 		);
 
@@ -551,25 +546,6 @@ class Admin {
 		}
 
 		$this->add_theme_page_for_tiob( $starter_site_data, 2 );
-	}
-
-	/**
-	 * Registers the onboarding page. Used for Neve onboarding, but hidden in the admin.
-	 *
-	 * @return void
-	 */
-	private function register_onboarding_page() {
-		$onboarding_data = array(
-			'page_title' => __( 'Onboarding', 'templates-patterns-collection' ),
-			'menu_title' => $this->get_prefix_for_menu_item() . __( 'Onboarding', 'templates-patterns-collection' ),
-			'capability' => 'install_plugins',
-			'menu_slug'  => 'neve-onboarding',
-			'callback'   => array(
-				$this,
-				'render_onboarding',
-			),
-		);
-		$this->add_theme_page_for_tiob( $onboarding_data, 4 );
 	}
 
 	/**
@@ -635,10 +611,6 @@ class Admin {
 			return false;
 		}
 		$this->register_starter_sites_page();
-
-		if ( $this->should_load_onboarding() ) {
-			$this->register_onboarding_page();
-		}
 
 		if ( $this->is_library_disabled() ) {
 			return false;

--- a/onboarding/src/store/reducer.js
+++ b/onboarding/src/store/reducer.js
@@ -24,7 +24,7 @@ const initialState = {
 	fetching: false,
 	searchQuery: '',
 	license: initialLicense,
-	onboardingStep: 1,
+	onboardingStep: window.location.search.includes('show=welcome') ? 1 : 2,
 	userCustomSettings: {
 		siteName: null,
 		siteLogo: null,
@@ -35,6 +35,7 @@ const initialState = {
 	trackingId: '',
 	refresh: false,
 };
+
 export default ( state = initialState, action ) => {
 	switch ( action.type ) {
 		case 'SET_CATEGORY':


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Make the sidebar menu redirect to the Onboarding workflow.
- Welcome step will be only for first time users (the auto redirect when the user install TPC for the first time) with URL param `show=welcome`

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Press on the `Starter Sites` under `Neve` menu. You should be redirected to onboarding.
- After you complete an import, you should still be able to access the onboarding via `Starter Sites` under `Neve` menu.

> [!NOTE]
> For Neve Dashboard shortcut, use https://github.com/Codeinwp/neve/pull/4351


https://github.com/user-attachments/assets/581b74f9-a94d-4a95-ae60-cfdf106984d0


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2910
<!-- Should look like this: `Closes #1, #2, #3.` . -->
