### PR TITLE
fix: ensure sites that can't be imported in current context are marked properly

### DIFF
--- a/includes/Sites_Listing.php
+++ b/includes/Sites_Listing.php
@@ -230,6 +230,6 @@ class Sites_Listing {
 			8 => 2,
 			9 => 3,
 		);
-		return ! isset( $category_mapping[ $category ] ) || $category_mapping[ $category ] < 2;
+		return apply_filters( 'product_neve_license_status', false ) !== 'valid' || ! isset( $category_mapping[ $category ] ) || $category_mapping[ $category ] < 2;
 	}
 }


### PR DESCRIPTION
### Summary
Make sure expired licenses do not list premium sites as importable. These were not previously importable, but were not locked in the UI.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Refer to this comment https://github.com/Codeinwp/neve-pro-addon/issues/2994#issuecomment-2865898694 
- Check that the websites are locked when the license is expired, inactive. 

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2994.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
