### PR TITLE
feat: integrate Slug Mapping functionality across importers

### DIFF
--- a/includes/Importers/Cleanup/Manager.php
+++ b/includes/Importers/Cleanup/Manager.php
@@ -8,6 +8,7 @@
  */
 namespace TIOB\Importers\Cleanup;
 
+use TIOB\Importers\Helpers\Slug_Mapping;
 use TIOB\Importers\Plugin_Importer;
 
 /**
@@ -293,6 +294,7 @@ class Manager {
 		$this->cleanup_attachments( $state );
 		$this->cleanup_widgets( $state );
 		$this->cleanup_plugins( $state );
+		Slug_Mapping::clear();
 
 		return delete_transient( Active_State::STATE_NAME );
 	}

--- a/includes/Importers/Content_Importer.php
+++ b/includes/Importers/Content_Importer.php
@@ -11,6 +11,7 @@ use TIOB\Admin;
 use TIOB\Importers\Cleanup\Active_State;
 use TIOB\Importers\Helpers\Helper;
 use TIOB\Importers\Helpers\Importer_Alterator;
+use TIOB\Importers\Helpers\Slug_Mapping;
 use TIOB\Logger;
 use TIOB\Importers\WP\WP_Import;
 use WP_Error;
@@ -221,7 +222,7 @@ class Content_Importer {
 		update_option( 'show_on_front', 'page' );
 
 		if ( isset( $args['front_page'] ) && $args['front_page'] !== null ) {
-			$front_page_obj = get_page_by_path( $this->cleanup_page_slug( $args['front_page'], $demo_slug ) );
+			$front_page_obj = $this->get_imported_page_by_slug( $args['front_page'], $demo_slug );
 			if ( isset( $front_page_obj->ID ) ) {
 				$front_page_options['page_on_front'] = get_option( 'page_on_front' );
 				update_option( 'page_on_front', $front_page_obj->ID );
@@ -229,7 +230,7 @@ class Content_Importer {
 		}
 
 		if ( isset( $args['blog_page'] ) && $args['blog_page'] !== null ) {
-			$blog_page_obj = get_page_by_path( $this->cleanup_page_slug( $args['blog_page'], $demo_slug ) );
+			$blog_page_obj = $this->get_imported_page_by_slug( $args['blog_page'], $demo_slug );
 			if ( isset( $blog_page_obj->ID ) ) {
 				$front_page_options['page_for_posts'] = get_option( 'page_for_posts' );
 				update_option( 'page_for_posts', $blog_page_obj->ID );
@@ -266,7 +267,7 @@ class Content_Importer {
 		$shop_page_options = array();
 		foreach ( $pages as $option_id => $slug ) {
 			if ( ! empty( $slug ) ) {
-				$page_object = get_page_by_path( $this->cleanup_page_slug( $slug, $demo_slug ) );
+				$page_object = $this->get_imported_page_by_slug( $slug, $demo_slug );
 				if ( isset( $page_object->ID ) ) {
 					$shop_page_options[ $option_id ] = get_option( $option_id );
 					update_option( $option_id, $page_object->ID );
@@ -414,6 +415,8 @@ class Content_Importer {
 	 * @return WP_Error|true
 	 */
 	public function import_file( $file_path, $req_body = array(), $builder = '' ) {
+		Slug_Mapping::clear();
+
 		if ( empty( $file_path ) || ! file_exists( $file_path ) || ! is_readable( $file_path ) ) {
 			return new WP_Error( 'ti__ob_content_err_1', 'No content file' );
 		}
@@ -422,6 +425,36 @@ class Content_Importer {
 		$importer  = new WP_Import( $builder );
 
 		return $importer->import( $file_path );
+	}
+
+	/**
+	 * Get imported page object by old slug.
+	 *
+	 * @param string $slug old page slug.
+	 * @param string $demo_slug demo slug.
+	 *
+	 * @return \WP_Post|null
+	 */
+	private function get_imported_page_by_slug( $slug, $demo_slug ) {
+		$mapped_slug = Slug_Mapping::resolve_slug( $slug );
+		$page        = get_page_by_path( $mapped_slug );
+		if ( $page instanceof \WP_Post ) {
+			return $page;
+		}
+
+		$normalized_slug = $this->normalize_page_slug( $slug, $demo_slug );
+		$page            = get_page_by_path( $normalized_slug );
+		if ( $page instanceof \WP_Post ) {
+			return $page;
+		}
+
+		$legacy_hashed_slug = $this->cleanup_page_slug( $slug, $demo_slug );
+		$page               = get_page_by_path( $legacy_hashed_slug );
+		if ( $page instanceof \WP_Post ) {
+			return $page;
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/Importers/Helpers/Helper.php
+++ b/includes/Importers/Helpers/Helper.php
@@ -101,21 +101,108 @@ trait Helper {
 	 *
 	 * @param string $slug      page slug.
 	 * @param string $demo_slug demo slug.
+	 * @param bool   $check_collisions should check if slug collisions exist before hashing.
+	 * @param array  $reserved_slugs additional reserved slugs from current import run.
 	 *
 	 * @return string
 	 */
-	public function cleanup_page_slug( $slug, $demo_slug ) {
+	public function cleanup_page_slug( $slug, $demo_slug, $check_collisions = false, $reserved_slugs = array() ) {
 		$unhashed = array( 'shop', 'my-account', 'checkout', 'cart', 'blog', 'news', 'lifter-courses', 'courses', 'dashboard', 'my-courses', 'memberships' );
-		$slug     = str_replace( $demo_slug, '', $slug );
-		$slug     = str_replace( 'demo', '', $slug );
-		$slug     = ltrim( $slug, '-' );
+		$slug     = $this->normalize_page_slug( $slug, $demo_slug );
+
+		if ( $slug === '' ) {
+			$slug = sanitize_title( $demo_slug );
+		}
 
 		if ( in_array( $slug, $unhashed, true ) ) {
 			return $slug;
 		}
 
 		$hash = substr( md5( $demo_slug ), 0, 5 );
-		$slug = $hash . '-' . $slug;
+		if ( ! $check_collisions ) {
+			return $hash . '-' . $slug;
+		}
+
+		if ( ! $this->is_page_slug_taken( $slug, $reserved_slugs ) ) {
+			return $slug;
+		}
+
+		$hashed_slug = $hash . '-' . $slug;
+
+		if ( ! $this->is_page_slug_taken( $hashed_slug, $reserved_slugs ) ) {
+			return $hashed_slug;
+		}
+
+		return $this->generate_unique_page_slug( $hashed_slug, $reserved_slugs );
+	}
+
+	/**
+	 * Normalize page slug before collision checks.
+	 *
+	 * @param string $slug      page slug.
+	 * @param string $demo_slug demo slug.
+	 *
+	 * @return string
+	 */
+	public function normalize_page_slug( $slug, $demo_slug ) {
+		$slug = str_replace( $demo_slug, '', $slug );
+		$slug = str_replace( 'demo', '', $slug );
+		$slug = ltrim( $slug, '-' );
+
+		return $slug;
+	}
+
+	/**
+	 * Check if page slug is already taken.
+	 *
+	 * @param string $slug           slug to check.
+	 * @param array  $reserved_slugs additional reserved slugs from current import.
+	 *
+	 * @return bool
+	 */
+	private function is_page_slug_taken( $slug, $reserved_slugs = array() ) {
+		if ( ! empty( $reserved_slugs ) && in_array( $slug, $reserved_slugs, true ) ) {
+			return true;
+		}
+
+		if ( $slug === '' ) {
+			return false;
+		}
+
+		return get_page_by_path( $slug, OBJECT, 'page' ) !== null;
+	}
+
+	/**
+	 * Generate unique page slug.
+	 *
+	 * @param string $base_slug      base slug.
+	 * @param array  $reserved_slugs additional reserved slugs from current import.
+	 *
+	 * @return string
+	 */
+	private function generate_unique_page_slug( $base_slug, $reserved_slugs = array() ) {
+		if ( function_exists( 'wp_unique_post_slug' ) ) {
+			$unique_slug = wp_unique_post_slug( $base_slug, 0, 'publish', 'page', 0 );
+			if ( ! in_array( $unique_slug, $reserved_slugs, true ) ) {
+				return $unique_slug;
+			}
+
+			$suffix = 2;
+			while ( in_array( $unique_slug, $reserved_slugs, true ) ) {
+				$unique_slug = wp_unique_post_slug( $base_slug . '-' . $suffix, 0, 'publish', 'page', 0 );
+				$suffix++;
+			}
+
+			return $unique_slug;
+		}
+
+		$suffix = 2;
+		$slug   = $base_slug;
+
+		while ( $this->is_page_slug_taken( $slug, $reserved_slugs ) ) {
+			$slug = $base_slug . '-' . $suffix;
+			$suffix++;
+		}
 
 		return $slug;
 	}

--- a/includes/Importers/Helpers/Importer_Alterator.php
+++ b/includes/Importers/Helpers/Importer_Alterator.php
@@ -9,6 +9,7 @@
 
 
 namespace TIOB\Importers\Helpers;
+
 /**
  * Class Importer_Alterator
  */
@@ -116,11 +117,31 @@ class Importer_Alterator {
 	 * @return array
 	 */
 	public function drop_slug_and_prefix_pages( $posts ) {
+		$slug_map       = array();
+		$reserved_slugs = array();
+
 		foreach ( $posts as $index => $post ) {
 			if ( $post['post_type'] !== 'page' ) {
 				continue;
 			}
-			$posts[ $index ]['post_name'] = $this->cleanup_page_slug( $post['post_name'], $this->site_json_data['demoSlug'] );
+
+			$old_slug = $post['post_name'];
+			$new_slug = $this->cleanup_page_slug(
+				$old_slug,
+				$this->site_json_data['demoSlug'],
+				true,
+				$reserved_slugs
+			);
+
+			$posts[ $index ]['post_name'] = $new_slug;
+			$reserved_slugs[]             = $new_slug;
+			if ( ! isset( $slug_map[ $old_slug ] ) ) {
+				$slug_map[ $old_slug ] = $new_slug;
+			}
+		}
+
+		if ( ! empty( $slug_map ) ) {
+			Slug_Mapping::set_slug_map( $slug_map );
 		}
 
 		return $posts;
@@ -135,7 +156,8 @@ class Importer_Alterator {
 	 * @return array
 	 */
 	public function change_nav_menu_item_link( $args, $import_source_url ) {
-		$args['menu-item-url'] = str_replace( $import_source_url, get_home_url(), $args['menu-item-url'] );
+		Slug_Mapping::register_source_url( $import_source_url );
+		$args['menu-item-url'] = Slug_Mapping::rewrite_url( $args['menu-item-url'] );
 
 		return $args;
 	}
@@ -151,8 +173,9 @@ class Importer_Alterator {
 	 * @return string
 	 */
 	public function replace_links( $content, $old_base_url ) {
-		$content = str_replace( $old_base_url, get_home_url(), $content );
+		Slug_Mapping::register_source_url( $old_base_url );
 		$content = $this->replace_image_urls( $content );
+		$content = Slug_Mapping::rewrite_value( $content );
 		return $content;
 	}
 

--- a/includes/Importers/Helpers/Slug_Mapping.php
+++ b/includes/Importers/Helpers/Slug_Mapping.php
@@ -295,10 +295,10 @@ class Slug_Mapping {
 		return preg_replace_callback(
 			'#https?:\\\\/\\\\/[^\s"\'<>()]+#i',
 			function ( $matches ) {
-				$escaped_url  = $matches[0];
-				$decoded_url  = str_replace( '\\/', '/', $escaped_url );
-				$rewritten    = self::rewrite_url( $decoded_url );
-				$rewritten    = str_replace( '/', '\\/', $rewritten );
+				$escaped_url = $matches[0];
+				$decoded_url = str_replace( '\\/', '/', $escaped_url );
+				$rewritten   = self::rewrite_url( $decoded_url );
+				$rewritten   = str_replace( '/', '\\/', $rewritten );
 
 				return $rewritten;
 			},

--- a/includes/Importers/Helpers/Slug_Mapping.php
+++ b/includes/Importers/Helpers/Slug_Mapping.php
@@ -1,0 +1,457 @@
+<?php
+/**
+ * Slug mapping helper.
+ *
+ * Keeps the old/new slug map and source URLs for the current import and
+ * provides URL rewrite helpers that use this state.
+ *
+ * @package templates-patterns-collection
+ */
+
+namespace TIOB\Importers\Helpers;
+
+/**
+ * Class Slug_Mapping
+ */
+class Slug_Mapping {
+
+	/**
+	 * Transient key used for the import slug mapping state.
+	 */
+	const TRANSIENT_KEY = 'ti_tpc_import_slug_mapping';
+
+	/**
+	 * Map array key.
+	 */
+	const MAP_KEY = 'slug_map';
+
+	/**
+	 * Source URLs array key.
+	 */
+	const SOURCES_KEY = 'source_urls';
+
+	/**
+	 * Persisted state expiration.
+	 */
+	const EXPIRATION = 12 * HOUR_IN_SECONDS;
+
+	/**
+	 * Clear stored state.
+	 *
+	 * @return void
+	 */
+	public static function clear() {
+		delete_transient( self::TRANSIENT_KEY );
+	}
+
+	/**
+	 * Set slug map.
+	 *
+	 * @param array $slug_map old slug => new slug map.
+	 *
+	 * @return void
+	 */
+	public static function set_slug_map( $slug_map ) {
+		if ( ! is_array( $slug_map ) ) {
+			return;
+		}
+
+		$state = self::get_state();
+		$map   = array();
+
+		foreach ( $slug_map as $old_slug => $new_slug ) {
+			if ( ! is_string( $old_slug ) || ! is_string( $new_slug ) ) {
+				continue;
+			}
+
+			$old_slug = trim( $old_slug );
+			$new_slug = trim( $new_slug );
+			if ( $old_slug === '' || $new_slug === '' ) {
+				continue;
+			}
+
+			$map[ $old_slug ] = $new_slug;
+		}
+
+		$state[ self::MAP_KEY ] = $map;
+		self::save_state( $state );
+	}
+
+	/**
+	 * Return the stored slug map.
+	 *
+	 * @return array
+	 */
+	public static function get_slug_map() {
+		$state = self::get_state();
+		return is_array( $state[ self::MAP_KEY ] ) ? $state[ self::MAP_KEY ] : array();
+	}
+
+	/**
+	 * Resolve a slug through the map.
+	 *
+	 * @param string $slug old slug.
+	 *
+	 * @return string
+	 */
+	public static function resolve_slug( $slug ) {
+		$map = self::get_slug_map();
+		if ( isset( $map[ $slug ] ) ) {
+			return $map[ $slug ];
+		}
+
+		return $slug;
+	}
+
+	/**
+	 * Register an import source URL.
+	 *
+	 * @param string $source_url source URL.
+	 *
+	 * @return void
+	 */
+	public static function register_source_url( $source_url ) {
+		if ( ! is_string( $source_url ) || empty( $source_url ) ) {
+			return;
+		}
+
+		$source_url = esc_url_raw( trim( $source_url ) );
+		if ( empty( $source_url ) ) {
+			return;
+		}
+
+		$state       = self::get_state();
+		$source_urls = isset( $state[ self::SOURCES_KEY ] ) && is_array( $state[ self::SOURCES_KEY ] ) ? $state[ self::SOURCES_KEY ] : array();
+
+		if ( ! in_array( $source_url, $source_urls, true ) ) {
+			$source_urls[] = $source_url;
+		}
+
+		$state[ self::SOURCES_KEY ] = $source_urls;
+		self::save_state( $state );
+	}
+
+	/**
+	 * Get all registered source URLs.
+	 *
+	 * @return array
+	 */
+	public static function get_source_urls() {
+		$state = self::get_state();
+		return isset( $state[ self::SOURCES_KEY ] ) && is_array( $state[ self::SOURCES_KEY ] ) ? $state[ self::SOURCES_KEY ] : array();
+	}
+
+	/**
+	 * Recursively rewrite internal links in a value.
+	 *
+	 * @param mixed $value value to rewrite.
+	 *
+	 * @return mixed
+	 */
+	public static function rewrite_value( $value ) {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $item ) {
+				$value[ $key ] = self::rewrite_value( $item );
+			}
+
+			return $value;
+		}
+
+		if ( is_string( $value ) ) {
+			return self::rewrite_string_value( $value );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Rewrite a single URL if it belongs to an import source.
+	 *
+	 * @param string $url URL.
+	 *
+	 * @return string
+	 */
+	public static function rewrite_url( $url ) {
+		if ( ! is_string( $url ) || empty( $url ) ) {
+			return $url;
+		}
+
+		$source_url = self::get_matching_source_url( $url );
+		if ( empty( $source_url ) ) {
+			return $url;
+		}
+
+		$url_parts    = wp_parse_url( $url );
+		$source_parts = wp_parse_url( $source_url );
+		$home_parts   = wp_parse_url( get_home_url() );
+
+		if ( ! is_array( $url_parts ) || ! is_array( $source_parts ) || ! is_array( $home_parts ) ) {
+			return $url;
+		}
+
+		$target_path = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
+		$source_path = isset( $source_parts['path'] ) ? rtrim( $source_parts['path'], '/' ) : '';
+		$home_path   = isset( $home_parts['path'] ) ? rtrim( $home_parts['path'], '/' ) : '';
+		$relative    = $target_path;
+
+		if ( ! empty( $source_path ) && $source_path !== '/' ) {
+			if ( $target_path === $source_path ) {
+				$relative = '';
+			} elseif ( strpos( $target_path, $source_path . '/' ) === 0 ) {
+				$relative = substr( $target_path, strlen( $source_path ) );
+			} else {
+				return $url;
+			}
+		}
+
+		$rewritten_relative = $relative;
+		if ( $rewritten_relative !== '' ) {
+			$rewritten_relative = self::replace_path_slugs( $rewritten_relative );
+		}
+
+		$new_path = $home_path . $rewritten_relative;
+		if ( $new_path === '' ) {
+			$new_path = '/';
+		}
+		if ( strpos( $new_path, '/' ) !== 0 ) {
+			$new_path = '/' . $new_path;
+		}
+
+		$url_parts['scheme'] = isset( $home_parts['scheme'] ) ? $home_parts['scheme'] : ( isset( $url_parts['scheme'] ) ? $url_parts['scheme'] : 'http' );
+		$url_parts['host']   = isset( $home_parts['host'] ) ? $home_parts['host'] : $url_parts['host'];
+		$url_parts['path']   = $new_path;
+
+		if ( isset( $home_parts['port'] ) ) {
+			$url_parts['port'] = $home_parts['port'];
+		} else {
+			unset( $url_parts['port'] );
+		}
+
+		if ( isset( $home_parts['user'] ) ) {
+			$url_parts['user'] = $home_parts['user'];
+		} else {
+			unset( $url_parts['user'] );
+		}
+
+		if ( isset( $home_parts['pass'] ) ) {
+			$url_parts['pass'] = $home_parts['pass'];
+		} else {
+			unset( $url_parts['pass'] );
+		}
+
+		return self::build_url( $url_parts );
+	}
+
+	/**
+	 * Rewrite string values and support serialized content.
+	 *
+	 * @param string $value string value.
+	 *
+	 * @return string
+	 */
+	private static function rewrite_string_value( $value ) {
+		if ( $value === '' ) {
+			return $value;
+		}
+
+		if ( is_serialized( $value ) ) {
+			$unserialized = maybe_unserialize( $value );
+			$rewritten    = self::rewrite_value( $unserialized );
+
+			return maybe_serialize( $rewritten );
+		}
+
+		$value = self::rewrite_plain_urls_in_string( $value );
+		$value = self::rewrite_escaped_urls_in_string( $value );
+
+		return $value;
+	}
+
+	/**
+	 * Rewrite plain URLs found in string.
+	 *
+	 * @param string $value value.
+	 *
+	 * @return string
+	 */
+	private static function rewrite_plain_urls_in_string( $value ) {
+		return preg_replace_callback(
+			'#https?://[^\s"\'<>()]+#i',
+			function ( $matches ) {
+				return self::rewrite_url( $matches[0] );
+			},
+			$value
+		);
+	}
+
+	/**
+	 * Rewrite escaped URLs found in string.
+	 *
+	 * @param string $value value.
+	 *
+	 * @return string
+	 */
+	private static function rewrite_escaped_urls_in_string( $value ) {
+		return preg_replace_callback(
+			'#https?:\\\\/\\\\/[^\s"\'<>()]+#i',
+			function ( $matches ) {
+				$escaped_url  = $matches[0];
+				$decoded_url  = str_replace( '\\/', '/', $escaped_url );
+				$rewritten    = self::rewrite_url( $decoded_url );
+				$rewritten    = str_replace( '/', '\\/', $rewritten );
+
+				return $rewritten;
+			},
+			$value
+		);
+	}
+
+	/**
+	 * Replace path segments using slug map.
+	 *
+	 * @param string $path path.
+	 *
+	 * @return string
+	 */
+	private static function replace_path_slugs( $path ) {
+		$map = self::get_slug_map();
+		if ( empty( $map ) || ! is_string( $path ) || $path === '' ) {
+			return $path;
+		}
+
+		if ( $path === '/' ) {
+			return $path;
+		}
+
+		$starts_with_slash = strpos( $path, '/' ) === 0;
+		$ends_with_slash   = substr( $path, -1 ) === '/';
+		$segments          = explode( '/', trim( $path, '/' ) );
+
+		foreach ( $segments as $index => $segment ) {
+			$decoded = rawurldecode( $segment );
+			if ( isset( $map[ $decoded ] ) ) {
+				$segments[ $index ] = rawurlencode( $map[ $decoded ] );
+			}
+		}
+
+		$new_path = implode( '/', $segments );
+		if ( $starts_with_slash ) {
+			$new_path = '/' . $new_path;
+		}
+		if ( $ends_with_slash && $new_path !== '/' ) {
+			$new_path .= '/';
+		}
+		if ( $new_path === '' ) {
+			$new_path = '/';
+		}
+
+		return $new_path;
+	}
+
+	/**
+	 * Return the matching source URL for a URL.
+	 *
+	 * @param string $url URL.
+	 *
+	 * @return string
+	 */
+	private static function get_matching_source_url( $url ) {
+		$url_parts = wp_parse_url( $url );
+		if ( ! is_array( $url_parts ) || ! isset( $url_parts['host'] ) ) {
+			return '';
+		}
+
+		$target_host = strtolower( $url_parts['host'] );
+		$target_path = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
+		$best_match  = '';
+		$best_length = -1;
+
+		foreach ( self::get_source_urls() as $source_url ) {
+			$source_parts = wp_parse_url( $source_url );
+			if ( ! is_array( $source_parts ) || ! isset( $source_parts['host'] ) ) {
+				continue;
+			}
+
+			if ( strtolower( $source_parts['host'] ) !== $target_host ) {
+				continue;
+			}
+
+			if ( isset( $source_parts['port'], $url_parts['port'] ) && (int) $source_parts['port'] !== (int) $url_parts['port'] ) {
+				continue;
+			}
+
+			$source_path = isset( $source_parts['path'] ) ? rtrim( $source_parts['path'], '/' ) : '';
+			if ( empty( $source_path ) || $source_path === '/' ) {
+				$path_length = 0;
+				if ( $path_length > $best_length ) {
+					$best_match  = $source_url;
+					$best_length = $path_length;
+				}
+				continue;
+			}
+
+			if ( $target_path === $source_path || strpos( $target_path, $source_path . '/' ) === 0 ) {
+				$path_length = strlen( $source_path );
+				if ( $path_length > $best_length ) {
+					$best_match  = $source_url;
+					$best_length = $path_length;
+				}
+			}
+		}
+
+		return $best_match;
+	}
+
+	/**
+	 * Build URL from parsed URL parts.
+	 *
+	 * @param array $parts parsed URL parts.
+	 *
+	 * @return string
+	 */
+	private static function build_url( $parts ) {
+		$scheme   = isset( $parts['scheme'] ) ? $parts['scheme'] . '://' : '';
+		$user     = isset( $parts['user'] ) ? $parts['user'] : '';
+		$pass     = isset( $parts['pass'] ) ? ':' . $parts['pass'] : '';
+		$auth     = ( $user || $pass ) ? "{$user}{$pass}@" : '';
+		$host     = isset( $parts['host'] ) ? $parts['host'] : '';
+		$port     = isset( $parts['port'] ) ? ':' . $parts['port'] : '';
+		$path     = isset( $parts['path'] ) ? $parts['path'] : '';
+		$query    = isset( $parts['query'] ) ? '?' . $parts['query'] : '';
+		$fragment = isset( $parts['fragment'] ) ? '#' . $parts['fragment'] : '';
+
+		return "{$scheme}{$auth}{$host}{$port}{$path}{$query}{$fragment}";
+	}
+
+	/**
+	 * Get state from transient.
+	 *
+	 * @return array
+	 */
+	private static function get_state() {
+		$state = get_transient( self::TRANSIENT_KEY );
+		if ( ! is_array( $state ) ) {
+			$state = array();
+		}
+
+		if ( ! isset( $state[ self::MAP_KEY ] ) || ! is_array( $state[ self::MAP_KEY ] ) ) {
+			$state[ self::MAP_KEY ] = array();
+		}
+		if ( ! isset( $state[ self::SOURCES_KEY ] ) || ! is_array( $state[ self::SOURCES_KEY ] ) ) {
+			$state[ self::SOURCES_KEY ] = array();
+		}
+
+		return $state;
+	}
+
+	/**
+	 * Save state.
+	 *
+	 * @param array $state state.
+	 *
+	 * @return void
+	 */
+	private static function save_state( $state ) {
+		set_transient( self::TRANSIENT_KEY, $state, self::EXPIRATION );
+	}
+}

--- a/includes/Importers/Theme_Mods_Importer.php
+++ b/includes/Importers/Theme_Mods_Importer.php
@@ -9,6 +9,7 @@ namespace TIOB\Importers;
 
 use TIOB\Importers\Cleanup\Active_State;
 use TIOB\Importers\Helpers\Helper;
+use TIOB\Importers\Helpers\Slug_Mapping;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -86,6 +87,7 @@ class Theme_Mods_Importer {
 			);
 		}
 		$this->source_url = $data['source_url'];
+		Slug_Mapping::register_source_url( $this->source_url );
 		$this->theme_mods = apply_filters( 'ti_tpc_theme_mods_pre_import', $data['theme_mods'] );
 		array_walk( $this->theme_mods, array( $this, 'change_theme_mods_root_url' ) );
 
@@ -114,6 +116,7 @@ class Theme_Mods_Importer {
 
 		$this->options = isset( $data['wp_options'] ) ? $data['wp_options'] : array();
 		foreach ( $this->options as $key => $value ) {
+			$value = Slug_Mapping::rewrite_value( $value );
 			if ( is_array( $value ) ) {
 				array_walk_recursive(
 					$value,
@@ -191,6 +194,7 @@ class Theme_Mods_Importer {
 	private function change_theme_mods_root_url( &$item ) {
 		do_action( 'themeisle_ob_before_change_theme_mods_root_url' );
 		$item = $this->replace_image_urls( $item );
+		$item = Slug_Mapping::rewrite_value( $item );
 		do_action( 'themeisle_ob_after_change_theme_mods_root_url' );
 	}
 

--- a/includes/Importers/WP/Elementor_Meta_Handler.php
+++ b/includes/Importers/WP/Elementor_Meta_Handler.php
@@ -10,6 +10,7 @@
 namespace TIOB\Importers\WP;
 
 use TIOB\Importers\Helpers\Helper;
+use TIOB\Importers\Helpers\Slug_Mapping;
 
 /**
  * Class Elementor_Meta_Handler
@@ -49,6 +50,7 @@ class Elementor_Meta_Handler {
 	public function __construct( $unfiltered_value, $site_url ) {
 		$this->value      = $unfiltered_value;
 		$this->import_url = $site_url;
+		Slug_Mapping::register_source_url( $site_url );
 	}
 
 	/**
@@ -89,25 +91,14 @@ class Elementor_Meta_Handler {
 			return;
 		}
 
-		$site_url  = get_site_url();
-		$url_parts = parse_url( $site_url );
-
 		array_walk_recursive(
 			$decoded_meta,
-			function ( &$value, $key ) use ( $site_url, $url_parts ) {
+			function ( &$value ) {
 				if ( filter_var( $value, FILTER_VALIDATE_URL ) === false ) {
 					return;
 				}
 
-				$url = parse_url( $value );
-
-				if ( ! isset( $url['host'] ) || ! isset( $url_parts['host'] ) ) {
-					return;
-				}
-
-				if ( $url['host'] !== $url_parts['host'] ) {
-					$value = str_replace( $this->import_url, $site_url, $value );
-				}
+				$value = Slug_Mapping::rewrite_value( $value );
 			}
 		);
 

--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -7,6 +7,7 @@ namespace TIOB\Importers\WP;
 
 use TIOB\Importers\Cleanup\Active_State;
 use TIOB\Importers\Helpers\Helper;
+use TIOB\Importers\Helpers\Slug_Mapping;
 use TIOB\Logger;
 use WP_Error;
 use WP_Importer;
@@ -125,6 +126,8 @@ class WP_Import extends WP_Importer {
 		$this->tags          = $import_data['tags'];
 		$this->base_url      = esc_url( $import_data['base_url'] );
 		$this->base_blog_url = esc_url( $import_data['base_blog_url'] );
+		Slug_Mapping::register_source_url( $this->base_url );
+		Slug_Mapping::register_source_url( $this->base_blog_url );
 		wp_defer_term_counting( true );
 		wp_defer_comment_counting( true );
 		do_action( 'import_start' );
@@ -584,15 +587,17 @@ class WP_Import extends WP_Importer {
 							$meta_handler = new Elementor_Meta_Handler( $value, $this->base_blog_url );
 							$meta_handler->filter_meta();
 							$this->logger->log( 'Filtered elementor meta.', 'success' );
+						} else {
+							$value = Slug_Mapping::rewrite_value( $value );
 						}
 						if ( in_array(
 							$key,
-							array(
-								'tve_custom_css',
-								'tve_content_before_more',
-								'tve_updated_post',
-							)
-						) ) {
+								array(
+									'tve_custom_css',
+									'tve_content_before_more',
+									'tve_updated_post',
+								)
+							) ) {
 							$value = $this->replace_image_urls( $value );
 						}
 						update_post_meta( $post_id, $key, $value );

--- a/includes/Importers/WP/WP_Import.php
+++ b/includes/Importers/WP/WP_Import.php
@@ -592,12 +592,12 @@ class WP_Import extends WP_Importer {
 						}
 						if ( in_array(
 							$key,
-								array(
-									'tve_custom_css',
-									'tve_content_before_more',
-									'tve_updated_post',
-								)
-							) ) {
+							array(
+								'tve_custom_css',
+								'tve_content_before_more',
+								'tve_updated_post',
+							)
+						) ) {
 							$value = $this->replace_image_urls( $value );
 						}
 						update_post_meta( $post_id, $key, $value );

--- a/includes/Importers/Widgets_Importer.php
+++ b/includes/Importers/Widgets_Importer.php
@@ -12,6 +12,7 @@
 namespace TIOB\Importers;
 
 use TIOB\Importers\Cleanup\Active_State;
+use TIOB\Importers\Helpers\Slug_Mapping;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -29,7 +30,19 @@ class Widgets_Importer {
 	 * @return WP_REST_Response
 	 */
 	public function import_widgets( WP_REST_Request $request ) {
-		$widgets = $request->get_json_params();
+		$params  = $request->get_json_params();
+		$widgets = $params;
+
+		if ( isset( $params['source_url'], $params['widgets'] ) && is_array( $params['widgets'] ) ) {
+			$widgets = $params['widgets'];
+		}
+
+		if ( isset( $params['source_url'] ) && is_string( $params['source_url'] ) ) {
+			Slug_Mapping::register_source_url( $params['source_url'] );
+			if ( is_array( $widgets ) && isset( $widgets['source_url'] ) ) {
+				unset( $widgets['source_url'] );
+			}
+		}
 
 		if ( empty( $widgets ) || ! is_array( $widgets ) ) {
 			return new WP_REST_Response(
@@ -121,6 +134,7 @@ class Widgets_Importer {
 
 				// Convert multidimensional objects to multidimensional arrays
 				$widget = json_decode( wp_json_encode( $widget ), true );
+				$widget = Slug_Mapping::rewrite_value( $widget );
 
 				// Does widget with identical settings already exist in same sidebar?
 				if ( ! $fail && isset( $widget_instances[ $id_base ] ) ) {
@@ -284,4 +298,3 @@ class Widgets_Importer {
 		update_option( 'sidebars_widgets', $clean_widgets );
 	}
 }
-

--- a/includes/WP_Cli.php
+++ b/includes/WP_Cli.php
@@ -12,6 +12,7 @@ namespace TIOB;
 
 use TIOB\Importers\Content_Importer;
 use TIOB\Importers\Helpers\Helper;
+use TIOB\Importers\Helpers\Slug_Mapping;
 use TIOB\Importers\Plugin_Importer;
 use TIOB\Importers\Theme_Mods_Importer;
 use TIOB\Importers\Widgets_Importer;
@@ -153,6 +154,9 @@ class WP_Cli {
 		}
 
 		$site = $sites[ $site_slug ];
+		if ( isset( $site['url'] ) ) {
+			Slug_Mapping::register_source_url( $site['url'] );
+		}
 
 		$json_array = $this->get_starter_site_json( $site );
 		$this->import_plugins_for_starter_site( $json_array );
@@ -209,6 +213,7 @@ class WP_Cli {
 				$json['theme_mods'],
 				function ( &$item ) {
 					$item = $this->replace_image_urls( $item );
+					$item = Slug_Mapping::rewrite_value( $item );
 				}
 			);
 
@@ -230,6 +235,7 @@ class WP_Cli {
 
 		if ( isset( $json['wp_options'] ) && ! empty( $json['wp_options'] ) ) {
 			foreach ( $json['wp_options'] as $key => $value ) {
+				$value = Slug_Mapping::rewrite_value( $value );
 				if ( $value === 'true' ) {
 					$value = true;
 				}
@@ -412,4 +418,3 @@ class WP_Cli {
 
 $ti_ob_cli = new WP_Cli();
 $ti_ob_cli->load_commands();
-

--- a/onboarding/src/Components/Steps/Import.js
+++ b/onboarding/src/Components/Steps/Import.js
@@ -213,7 +213,10 @@ const Import = ( {
 		}
 		setCurrentStep( 'widgets' );
 		console.log( '[P] Widgets.' );
-		importWidgets( importData.widgets )
+		importWidgets( {
+			widgets: importData.widgets,
+			source_url: importData.url,
+		} )
 			.then( ( response ) => {
 				if ( ! response.success ) {
 					handleError( response, 'widgets' );

--- a/tests/digital-test.php
+++ b/tests/digital-test.php
@@ -6,6 +6,7 @@
  */
 
 use TIOB\Importers\Widgets_Importer;
+use TIOB\Importers\Helpers\Slug_Mapping;
 use TIOB\Main;
 use TIOB\Rest_Server;
 
@@ -173,6 +174,9 @@ class Digital_Rest_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_REST_Response', $response );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $response->get_data()['success'] );
+		$slug_map = Slug_Mapping::get_slug_map();
+		$this->assertArrayHasKey( 'home', $slug_map );
+		$this->assertSame( 'home', $slug_map['home'] );
 
 		//Test that there are NO placeholders left unprocessed
 		$placeholders_list = array( 'replace_cat' ); // add more if other placeholders are added
@@ -222,7 +226,10 @@ class Digital_Rest_Test extends WP_UnitTestCase {
 		$request->set_method( 'POST' );
 		$request->set_body(
 			json_encode(
-				$this->json['widgets']
+				array(
+					'widgets'    => $this->json['widgets'],
+					'source_url' => 'https://demosites.io/digital-store-gb',
+				)
 			)
 		);
 
@@ -252,6 +259,17 @@ class Digital_Rest_Test extends WP_UnitTestCase {
 					array_push( $accepted_titles, $widget['title'] );
 				}
 			}
+		}
+
+		$featured_widget = array_filter(
+			$widget_instances,
+			function ( $instance ) {
+				return isset( $instance['title'] ) && $instance['title'] === 'Featured product';
+			}
+		);
+		if ( ! empty( $featured_widget ) ) {
+			$featured_widget = array_shift( $featured_widget );
+			$this->assertSame( trailingslashit( get_home_url() ) . 'shop/', $featured_widget['link_url'] );
 		}
 
 		foreach ( $widget_instances as $widget_instance ) {

--- a/tests/rest-test.php
+++ b/tests/rest-test.php
@@ -6,6 +6,7 @@
  */
 
 use TIOB\Importers\Widgets_Importer;
+use TIOB\Importers\Helpers\Slug_Mapping;
 use TIOB\Main;
 use TIOB\Rest_Server;
 
@@ -145,6 +146,9 @@ class Onboarding_Rest_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_REST_Response', $response );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $response->get_data()[ 'success' ] );
+		$slug_map = Slug_Mapping::get_slug_map();
+		$this->assertSame( 'neve-charity--home', $slug_map[ 'neve-charity-demo-home' ] );
+		$this->assertSame( 'neve-charity--blog', $slug_map[ 'neve-charity-demo-blog' ] );
 
 		//Test that front page has been set up.
 		$this->assertEquals( 'page', get_option( 'show_on_front' ) );

--- a/tests/slug-mapping-test.php
+++ b/tests/slug-mapping-test.php
@@ -1,0 +1,363 @@
+<?php
+/**
+ * Slug mapping and import rewrite tests.
+ *
+ * @package templates-patterns-collection
+ */
+
+use TIOB\Importers\Content_Importer;
+use TIOB\Importers\Cleanup\Manager;
+use TIOB\Importers\Helpers\Helper;
+use TIOB\Importers\Helpers\Importer_Alterator;
+use TIOB\Importers\Helpers\Slug_Mapping;
+use TIOB\Importers\Theme_Mods_Importer;
+use TIOB\Importers\Widgets_Importer;
+
+/**
+ * Class Slug_Mapping_Test
+ */
+class Slug_Mapping_Test extends WP_UnitTestCase {
+	/**
+	 * @var int
+	 */
+	public static $admin_id;
+
+	/**
+	 * @param \WP_UnitTest_Factory $factory test factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_id );
+		Slug_Mapping::clear();
+	}
+
+	public function tearDown(): void {
+		Slug_Mapping::clear();
+		remove_theme_mod( 'test_link' );
+		delete_option( 'test_option_link' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Helpers\Slug_Mapping::rewrite_value
+	 */
+	public function test_rewrite_value_rewrites_only_internal_source_urls() {
+		Slug_Mapping::set_slug_map(
+			array(
+				'old-page' => 'new-page',
+			)
+		);
+		Slug_Mapping::register_source_url( 'https://demo.example.com/site' );
+
+		$input  = 'First: https://demo.example.com/site/old-page/?foo=bar Second: https://other.example.com/site/old-page/';
+		$output = Slug_Mapping::rewrite_value( $input );
+
+		$expected_internal = trailingslashit( get_home_url() ) . 'new-page/?foo=bar';
+		$this->assertStringContainsString( $expected_internal, $output );
+		$this->assertStringContainsString( 'https://other.example.com/site/old-page/', $output );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Helpers\Slug_Mapping::rewrite_value
+	 */
+	public function test_rewrite_value_handles_serialized_values() {
+		Slug_Mapping::set_slug_map(
+			array(
+				'old-page' => 'new-page',
+			)
+		);
+		Slug_Mapping::register_source_url( 'https://demo.example.com/site' );
+
+		$input = maybe_serialize(
+			array(
+				'url' => 'https://demo.example.com/site/old-page/?foo=bar',
+			)
+		);
+
+		$output   = Slug_Mapping::rewrite_value( $input );
+		$decoded  = maybe_unserialize( $output );
+		$expected = trailingslashit( get_home_url() ) . 'new-page/?foo=bar';
+
+		$this->assertTrue( is_array( $decoded ) );
+		$this->assertSame( $expected, $decoded['url'] );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Helpers\Slug_Mapping::rewrite_value
+	 */
+	public function test_rewrite_value_prefers_most_specific_source_path() {
+		$original_home    = get_option( 'home' );
+		$original_siteurl = get_option( 'siteurl' );
+
+		update_option( 'home', 'https://network.test/tpc' );
+		update_option( 'siteurl', 'https://network.test/tpc' );
+
+		try {
+			Slug_Mapping::register_source_url( 'https://demosites.io' );
+			Slug_Mapping::register_source_url( 'https://demosites.io/design-eng' );
+
+			$anchor_link  = Slug_Mapping::rewrite_value( 'https://demosites.io/design-eng/#work' );
+			$project_link = Slug_Mapping::rewrite_value( 'https://demosites.io/design-eng/projects/' );
+
+			$this->assertSame( 'https://network.test/tpc/#work', $anchor_link );
+			$this->assertSame( 'https://network.test/tpc/projects/', $project_link );
+		} finally {
+			update_option( 'home', $original_home );
+			update_option( 'siteurl', $original_siteurl );
+		}
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Helpers\Helper::cleanup_page_slug
+	 */
+	public function test_cleanup_page_slug_only_hashes_when_slug_is_taken() {
+		$helper = new class {
+			use Helper;
+		};
+
+		$clean_slug = $helper->cleanup_page_slug( 'test-demo-home', 'test-demo', true );
+		$this->assertSame( 'home', $clean_slug );
+
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Existing Home',
+				'post_name'   => 'home',
+			)
+		);
+
+		$hash       = substr( md5( 'test-demo' ), 0, 5 );
+		$hashed     = $hash . '-home';
+		$hashed_slug = $helper->cleanup_page_slug( 'test-demo-home', 'test-demo', true );
+		$this->assertSame( $hashed, $hashed_slug );
+
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Existing Hashed Home',
+				'post_name'   => $hashed,
+			)
+		);
+
+		$unique_hashed_slug = $helper->cleanup_page_slug( 'test-demo-home', 'test-demo', true );
+		$this->assertSame( $hashed . '-2', $unique_hashed_slug );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Helpers\Importer_Alterator::drop_slug_and_prefix_pages
+	 */
+	public function test_drop_slug_and_prefix_pages_persists_slug_map() {
+		$alterator = new Importer_Alterator(
+			array(
+				'demoSlug' => 'test-demo',
+			)
+		);
+
+		$posts = array(
+			array(
+				'post_type' => 'page',
+				'post_name' => 'test-demo-home',
+			),
+			array(
+				'post_type' => 'page',
+				'post_name' => 'home',
+			),
+			array(
+				'post_type' => 'post',
+				'post_name' => 'regular-post',
+			),
+		);
+
+		$processed_posts = $alterator->drop_slug_and_prefix_pages( $posts );
+		$hash            = substr( md5( 'test-demo' ), 0, 5 );
+
+		$this->assertSame( 'home', $processed_posts[0]['post_name'] );
+		$this->assertSame( $hash . '-home', $processed_posts[1]['post_name'] );
+		$this->assertSame( 'regular-post', $processed_posts[2]['post_name'] );
+
+		$slug_map = Slug_Mapping::get_slug_map();
+		$this->assertSame( 'home', $slug_map['test-demo-home'] );
+		$this->assertSame( $hash . '-home', $slug_map['home'] );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Helpers\Importer_Alterator::replace_links
+	 */
+	public function test_replace_links_rewrites_internal_links_to_mapped_slug() {
+		Slug_Mapping::set_slug_map(
+			array(
+				'old-page' => 'new-page',
+			)
+		);
+
+		$reflection = new ReflectionClass( Importer_Alterator::class );
+		$alterator  = $reflection->newInstanceWithoutConstructor();
+
+		$output   = $alterator->replace_links( 'Visit https://demo.example.com/site/old-page/', 'https://demo.example.com/site' );
+		$expected = trailingslashit( get_home_url() ) . 'new-page/';
+
+		$this->assertSame( 'Visit ' . $expected, $output );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Content_Importer::setup_front_page
+	 */
+	public function test_setup_front_page_uses_slug_map_resolution() {
+		Slug_Mapping::set_slug_map(
+			array(
+				'old-front' => 'new-front',
+				'old-blog'  => 'new-blog',
+			)
+		);
+
+		$front_page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Front',
+				'post_name'   => 'new-front',
+			)
+		);
+		$blog_page_id  = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Blog',
+				'post_name'   => 'new-blog',
+			)
+		);
+
+		$importer = new Content_Importer();
+		$importer->setup_front_page(
+			array(
+				'front_page' => 'old-front',
+				'blog_page'  => 'old-blog',
+			),
+			'test-demo'
+		);
+
+		$this->assertSame( $front_page_id, (int) get_option( 'page_on_front' ) );
+		$this->assertSame( $blog_page_id, (int) get_option( 'page_for_posts' ) );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Theme_Mods_Importer::import_theme_mods
+	 */
+	public function test_theme_mods_import_rewrites_links_with_slug_map() {
+		Slug_Mapping::set_slug_map(
+			array(
+				'old-page' => 'new-page',
+			)
+		);
+
+		$request = new WP_REST_Request();
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_method( 'POST' );
+		$request->set_body(
+			json_encode(
+				array(
+					'source_url' => 'https://demo.example.com/site',
+					'theme_mods' => array(
+						'test_link' => 'https://demo.example.com/site/old-page/',
+					),
+					'wp_options' => array(
+						'test_option_link' => 'https://demo.example.com/site/old-page/',
+					),
+				)
+			)
+		);
+
+		$importer = new Theme_Mods_Importer();
+		$response = $importer->import_theme_mods( $request );
+		$expected = trailingslashit( get_home_url() ) . 'new-page/';
+
+		$this->assertTrue( $response->get_data()['success'] );
+		$this->assertSame( $expected, get_theme_mod( 'test_link' ) );
+		$this->assertSame( $expected, get_option( 'test_option_link' ) );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Content_Importer::import_file
+	 */
+	public function test_new_content_import_clears_stale_slug_map() {
+		Slug_Mapping::set_slug_map(
+			array(
+				'stale-old' => 'stale-new',
+			)
+		);
+
+		$importer = new Content_Importer();
+		$result   = $importer->import_file( '/tmp/definitely-missing-import.xml' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array(), Slug_Mapping::get_slug_map() );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Widgets_Importer::import_widgets
+	 */
+	public function test_widgets_import_accepts_wrapped_payload() {
+		$request = new WP_REST_Request();
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_method( 'POST' );
+		$request->set_body(
+			json_encode(
+				array(
+					'source_url' => 'https://demo.example.com/site',
+					'widgets'    => array(),
+				)
+			)
+		);
+
+		$importer = new Widgets_Importer();
+		$response = $importer->import_widgets( $request );
+
+		$this->assertTrue( $response->get_data()['success'] );
+		$this->assertTrue( in_array( 'https://demo.example.com/site', Slug_Mapping::get_source_urls(), true ) );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Widgets_Importer::import_widgets
+	 */
+	public function test_widgets_import_accepts_legacy_raw_payload() {
+		$request = new WP_REST_Request();
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_method( 'POST' );
+		$request->set_body(
+			json_encode(
+				array(
+					'blog-sidebar' => array(),
+				)
+			)
+		);
+
+		$importer = new Widgets_Importer();
+		$response = $importer->import_widgets( $request );
+
+		$this->assertTrue( $response->get_data()['success'] );
+	}
+
+	/**
+	 * @covers \TIOB\Importers\Cleanup\Manager::do_cleanup
+	 */
+	public function test_cleanup_clears_slug_mapping_state() {
+		Slug_Mapping::set_slug_map(
+			array(
+				'old-page' => 'new-page',
+			)
+		);
+		Slug_Mapping::register_source_url( 'https://demo.example.com/site' );
+
+		$cleanup = new Manager();
+		$cleanup->do_cleanup();
+
+		$this->assertSame( array(), Slug_Mapping::get_slug_map() );
+		$this->assertSame( array(), Slug_Mapping::get_source_urls() );
+	}
+}


### PR DESCRIPTION
- Added Slug_Mapping usage in WP_Cli, Content_Importer, Theme_Mods_Importer, Widgets_Importer, and Elementor_Meta_Handler to handle source URLs and rewrite values.
- Introduced a new method in Content_Importer to get imported page objects by old slugs.
- Enhanced cleanup and slug generation logic in Helper and Importer_Alterator to support collision checks and unique slug generation.
- Updated tests to validate Slug_Mapping functionality and ensure correct slug handling during imports.
 
