### PR TITLE
feat(onboarding): support TI_ONBOARDING_DEFAULT_SITE redirect

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -398,15 +398,16 @@ class Admin {
 		}
 
 		delete_option( 'tpc_maybe_run_onboarding' );
-		wp_safe_redirect(
-			add_query_arg(
-				array(
-					'page' => 'neve-onboarding',
-					'show' => 'welcome',
-				),
-				admin_url( 'admin.php' )
-			)
-		);
+
+		$query_args = array( 'page' => 'neve-onboarding' );
+
+		if ( defined( 'TI_ONBOARDING_DEFAULT_SITE' ) && TI_ONBOARDING_DEFAULT_SITE ) {
+			$query_args['site'] = sanitize_key( TI_ONBOARDING_DEFAULT_SITE );
+		} else {
+			$query_args['show'] = 'welcome';
+		}
+
+		wp_safe_redirect( add_query_arg( $query_args, admin_url( 'admin.php' ) ) );
 		exit();
 	}
 

--- a/onboarding/src/store/reducer.js
+++ b/onboarding/src/store/reducer.js
@@ -16,15 +16,32 @@ const initialLicense = licenseTIOB || {
 	tier: 0,
 };
 
+const params = new URLSearchParams( window.location.search );
+const defaultSiteSlug = params.get( 'site' );
+
+const findSiteBySlug = ( slug ) => {
+	const builders = onboarding?.sites?.sites || {};
+	for ( const builder of Object.keys( builders ) ) {
+		if ( builders[ builder ]?.[ slug ] ) {
+			return builders[ builder ][ slug ];
+		}
+	}
+	return null;
+};
+
+const defaultSite = defaultSiteSlug ? findSiteBySlug( defaultSiteSlug ) : null;
+
 const initialState = {
 	sites: onboarding.sites || {},
 	editor: selectedEditor,
 	category: '',
-	currentSite: null,
+	currentSite: defaultSite,
 	fetching: false,
 	searchQuery: '',
 	license: initialLicense,
-	onboardingStep: window.location.search.includes('show=welcome') ? 1 : 2,
+	onboardingStep: defaultSite
+		? 3
+		: ( window.location.search.includes('show=welcome') ? 1 : 2 ),
 	userCustomSettings: {
 		siteName: null,
 		siteLogo: null,


### PR DESCRIPTION
## Summary

Adds a new opt-in mechanism to deep-link the onboarding wizard straight to the preview/import screen for a specific starter site.

- When the PHP constant `TI_ONBOARDING_DEFAULT_SITE` is defined, `Admin::activation_redirect()` now sends users to `admin.php?page=neve-onboarding&site=<slug>` instead of the welcome/search screen.
- The onboarding store reads `?site=<slug>` on boot, looks the slug up across all builders in `tiobDash.onboarding.sites.sites`, and starts at step 3 (`CustomizeSite` / preview + Import) with `currentSite` preset.
- If the slug is missing or unknown, behaviour falls back to the existing search screen (no broken state).

Use case: distributions and embedded environments (e.g. WordPress Playground demos) that want to drop a user directly into the import flow for a chosen site.

## Test plan

- [ ] Without the constant: re-activate the plugin and confirm the redirect still goes to `?page=neve-onboarding&show=welcome` (welcome step).
- [ ] With `define( 'TI_ONBOARDING_DEFAULT_SITE', 'web-design-agency' );` in `wp-config.php`: re-activate the plugin and confirm the redirect goes to `?page=neve-onboarding&site=web-design-agency`, app boots on the preview screen with the site preselected and the Import panel visible.
- [ ] Open `?page=neve-onboarding&site=does-not-exist` directly: app falls back to the search screen instead of breaking.
