### PR TITLE
fix(onboarding): source step 3 typography from imported site

### DIFF
--- a/onboarding/src/Components/CustomizeControls/TypographyControl.js
+++ b/onboarding/src/Components/CustomizeControls/TypographyControl.js
@@ -5,23 +5,41 @@ import classnames from 'classnames';
 import SVG from '../../utils/svg';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
 
-const TypographyControl = ( { siteStyle, handleFontClick, importData } ) => {
-	const themeMods = importData?.theme_mods;
+const FALLBACK_FONT = 'Arial, Helvetica, sans-serif';
 
-	const [ defaultBodyFont ] = useState(
-		themeMods?.neve_body_font_family || 'Arial, Helvetica, sans-serif'
-	);
-
-	const [ defaultHeadingsFont ] = useState(
-		themeMods?.neve_headings_font_family || 'Arial, Helvetica, sans-serif'
-	);
-
-	const { font } = siteStyle;
-	if ( ! tiobDash || ! tiobDash.fontParings ) {
-		return;
+const getFontPairs = ( importData ) => {
+	if ( importData && importData.font_pairs && Object.keys( importData.font_pairs ).length ) {
+		return importData.font_pairs;
 	}
+	if ( tiobDash && tiobDash.fontParings ) {
+		return tiobDash.fontParings;
+	}
+	return null;
+};
+
+const getDefaultFonts = ( importDataDefault ) => {
+	const themeMods = importDataDefault?.theme_mods;
+	return {
+		body: themeMods?.neve_body_font_family || FALLBACK_FONT,
+		heading: themeMods?.neve_headings_font_family || FALLBACK_FONT,
+	};
+};
+
+const TypographyControl = ( {
+	siteStyle,
+	handleFontClick,
+	importData,
+	importDataDefault,
+} ) => {
+	const fontPairs = getFontPairs( importData );
+	if ( ! fontPairs ) {
+		return null;
+	}
+
+	const { body: defaultBodyFont, heading: defaultHeadingsFont } =
+		getDefaultFonts( importDataDefault );
+	const { font } = siteStyle;
 
 	return (
 		<div className="ob-ctrl">
@@ -45,9 +63,8 @@ const TypographyControl = ( { siteStyle, handleFontClick, importData } ) => {
 					{ __( 'Default', 'templates-patterns-collection' ) }
 				</Button>
 
-				{ Object.keys( tiobDash.fontParings ).map( ( slug ) => {
-					const { headingFont, bodyFont } =
-						tiobDash.fontParings[ slug ];
+				{ Object.keys( fontPairs ).map( ( slug ) => {
+					const { headingFont, bodyFont } = fontPairs[ slug ];
 					const headingStyle = {
 						fontFamily: headingFont.font,
 					};
@@ -82,15 +99,12 @@ export default compose(
 	withDispatch(
 		(
 			dispatch,
-			{
-				importData,
-				siteStyle,
-				setSiteStyle,
-				defaultBodyFont,
-				defaultHeadingsFont,
-			}
+			{ importData, importDataDefault, siteStyle, setSiteStyle }
 		) => {
 			const { setImportData, setRefresh } = dispatch( 'ti-onboarding' );
+			const fontPairs = getFontPairs( importData );
+			const { body: defaultBodyFont, heading: defaultHeadingsFont } =
+				getDefaultFonts( importDataDefault );
 
 			return {
 				handleFontClick: ( fontKey ) => {
@@ -100,13 +114,15 @@ export default compose(
 					};
 					setSiteStyle( newStyle );
 
-					const { bodyFont, headingFont } =
-						fontKey !== 'default'
-							? tiobDash.fontParings[ fontKey ]
+					const pair =
+						fontKey !== 'default' && fontPairs && fontPairs[ fontKey ]
+							? fontPairs[ fontKey ]
 							: {
 									bodyFont: { font: defaultBodyFont },
 									headingFont: { font: defaultHeadingsFont },
 							  };
+
+					const { bodyFont, headingFont } = pair;
 
 					const newImportData = {
 						...importData,

--- a/onboarding/src/Components/SiteSettings.js
+++ b/onboarding/src/Components/SiteSettings.js
@@ -189,6 +189,9 @@ export const SiteSettings = ( {
 										<TypographyControl
 											siteStyle={ siteStyle }
 											setSiteStyle={ setSiteStyle }
+											importDataDefault={
+												importDataDefault
+											}
 										/>
 									</>
 								) }


### PR DESCRIPTION
## Summary

Makes the step 3 Typography control behave like the Palette control: the list of font pairs is driven by `importData.font_pairs` (returned by the demo site's `/wp-json/ti-demo-data/data` endpoint) instead of `tiobDash.fontParings`, which was populated from the **admin** site's local Neve settings.

This is the consumer half of a two-PR change. The exporter PR that adds `font_pairs` to the REST response is https://github.com/Codeinwp/demo-data-exporter/pull/new/fix/export-font-pairs.

## Why

Before this change, step 3 showed the admin site's Neve font pairs while the preview iframe resolved clicked slugs against the demo site's font pairs (via Demo Data Exporter's `eventHandlerData.fonts`). The two lists drift in content and in the `-<index>` suffix generated by `get_slug_from_font_pair(...) . '-' . $index`, so clicks often posted a slug the iframe could not find. `getFontStyle()` then returned `''` and `document.documentElement.style.cssText = paletteStyle + fontStyle` wiped the typography CSS vars — the preview fell back to browser defaults instead of the imported site's fonts.

The Default/reset button was also broken: the component stored `defaultBodyFont` / `defaultHeadingsFont` via `useState` in the component body, but `withDispatch` destructured them from `ownProps` where they were always `undefined`. Clicking "Default" wrote `neve_body_font_family: undefined, neve_headings_font_family: undefined` to `importData`, so the iframe lookup for `fonts.default` returned nothing and the preview fonts disappeared entirely.

## Changes

- `onboarding/src/Components/CustomizeControls/TypographyControl.js`
  - Read the font pair list via a `getFontPairs(importData)` helper that prefers `importData.font_pairs` (the demo site's list) and falls back to `tiobDash.fontParings` so older demos still render.
  - Derive default fonts with a `getDefaultFonts(importDataDefault)` helper. Both the component body (for the button tooltip) and the `withDispatch` click handler use the same resolver, pulling from `importDataDefault.theme_mods.neve_body_font_family` / `neve_headings_font_family`. Removes the stale `useState` + `ownProps` pattern.
  - `handleFontClick` now reads the selected pair from the resolved map (not `tiobDash.fontParings`) and only falls back to defaults when the slug genuinely isn't present.
- `onboarding/src/Components/SiteSettings.js`: pass `importDataDefault` into `<TypographyControl />`, mirroring the existing `<LogoControl importDataDefault={...} />` wiring.

No change to the `styleChange` protocol or the iframe handler — slugs now align because both sides read from `Dde_Palette_Switcher`.

## Test plan

- [ ] `npm run build:onboarding` compiles cleanly (verified locally).
- [ ] On a demo subsite that serves the new `font_pairs` from DDE: step 3 font strip matches the demo site's Neve font pairs.
- [ ] Click any pair: preview iframe typography updates to the selected pair (no empty CSS vars).
- [ ] Click "Default" / reset icon: preview reverts to the demo site's actual defaults; `importData.theme_mods.neve_body_font_family` / `neve_headings_font_family` are populated (not `undefined`).
- [ ] Complete step 5 import — final site typography matches the pair selected on step 3.
- [ ] Against a demo site without `font_pairs` in its REST response (older DDE): control gracefully falls back to `tiobDash.fontParings` (pre-PR behavior).

Made with [Cursor](https://cursor.com)