### PR TITLE
Refresh onboarding discovery flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# Agent Workflow
+
+## Project Overview
+
+Templates Patterns Collection is a WordPress plugin that powers ThemeIsle's starter sites, page templates, block patterns, and onboarding flows for Neve. It combines PHP import/orchestration code with multiple React-based admin/editor integrations for Gutenberg, Elementor, Beaver Builder, and onboarding.
+
+## Build & Development Commands
+
+### Setup
+
+```bash
+composer install
+yarn install --frozen-lockfile
+```
+
+### Production Build
+
+```bash
+# Full build: JS/CSS bundles + RTL files + POT generation
+yarn run build
+```
+
+`yarn run build` includes `build:makepot`, which requires Docker/WordPress CLI. If Docker is unavailable, build the assets only:
+
+```bash
+yarn run build:js
+yarn run build:onboarding
+yarn run build:editor
+yarn run build:elementor
+yarn run build:beaver
+yarn run rtlcss:app
+yarn run rtlcss:onboarding
+yarn run rtlcss:editor
+yarn run rtlcss:elementor
+yarn run rtlcss:beaver
+```
+
+### Development
+
+```bash
+yarn run dev
+
+# Individual watch targets
+yarn run watch:js
+yarn run watch:onboarding
+yarn run watch:editor
+yarn run watch:elementor
+yarn run watch:beaver
+```
+
+## Linting & Formatting
+
+```bash
+# JavaScript
+yarn run lint
+yarn run lint:onboarding
+yarn run format
+
+# PHP
+composer run lint
+composer run format
+composer run phpstan
+```
+
+## Testing
+
+```bash
+# PHP
+./vendor/bin/phpunit
+
+# E2E
+yarn run ci:e2e
+```
+
+`yarn run ci:e2e` reinstalls `e2e-tests` dependencies, starts the wp-env test environment, installs Playwright Chromium, and runs the browser suite.
+
+## Architecture
+
+### Bootstrap & Runtime
+
+- `templates-patterns-collection.php`: plugin bootstrap, constants, Composer autoload, activation/onboarding hooks.
+- `includes/Main.php`: main runtime coordinator and singleton entry point.
+- `includes/Rest_Server.php`: plugin REST API routes.
+- `includes/Admin.php`: wp-admin screens, onboarding triggers, AJAX endpoints, notices, logs.
+
+The plugin uses the `TIOB\*` namespace from `includes/`.
+
+### Import / Template Domain
+
+- `includes/Importers/`: core import pipeline for content, plugins, widgets, theme mods, cleanup, and WordPress WXR parsing.
+- `includes/Importers/WP/`: customized WordPress importer internals and builder-specific meta handlers.
+- `includes/Importers/Helpers/`: import support utilities and mapping logic.
+- `migration/`: migration code for legacy site/template data.
+
+### Editor & Builder Integrations
+
+- `includes/Editor.php`: Gutenberg/editor registration and editor-side bootstrapping.
+- `includes/Elementor.php`: Elementor editor integration.
+- `includes/TI_Beaver.php`: Beaver Builder integration and AJAX handlers.
+- `editor/`: Gutenberg/site editor React app.
+- `elementor/`: Elementor React app/assets.
+- `beaver/`: Beaver Builder React app/assets.
+
+### UI Apps
+
+- `assets/`: main templates library/admin app.
+- `onboarding/`: first-run onboarding React app.
+- `shared/`: shared JS helpers consumed across apps.
+
+Each app follows a `src/` -> `build/` pipeline powered by `@wordpress/scripts`, with separate RTL generation.
+
+## Folder/Subfolder Search Map
+
+| Path | What lives here | Start here when... |
+|---|---|---|
+| `templates-patterns-collection.php` | Bootstrap, constants, plugin startup, activation hooks | You need to trace plugin boot order |
+| `includes/Main.php` | Main singleton wiring for runtime services | You are following how features are registered |
+| `includes/Admin.php` | Admin UI wiring, notices, AJAX handlers, onboarding gates | A wp-admin flow or notice is broken |
+| `includes/Rest_Server.php` | REST routes used by imports and UI apps | A React flow fails on API calls |
+| `includes/Editor.php` | Gutenberg/block editor integration | Site editor or block editor behavior needs changes |
+| `includes/Elementor.php` | Elementor integration hooks | The issue only appears in Elementor |
+| `includes/TI_Beaver.php` | Beaver Builder integration and AJAX actions | The issue only appears in Beaver Builder |
+| `includes/Importers/` | Import pipeline for templates, content, plugins, widgets, cleanup | Imported content or starter-site setup is wrong |
+| `includes/Importers/WP/` | WXR importer internals and builder-specific content parsing | You are debugging low-level import parsing |
+| `assets/src/` | Main templates library React app source | The primary template browser/import UI needs changes |
+| `assets/build/` | Compiled main app assets | You are verifying generated output |
+| `onboarding/src/` | Onboarding UI source | First-run user journey needs changes |
+| `editor/src/` | Gutenberg/site editor app source | Editor insertion/import UX needs changes |
+| `elementor/src/` | Elementor app source | Elementor-side template UI needs changes |
+| `beaver/src/` | Beaver Builder app source | Beaver-side template UI needs changes |
+| `shared/` | Shared utilities/modules used by multiple apps | Logic is duplicated across apps or shared state is involved |
+| `migration/` | Legacy migration scripts | You are handling upgrades or data carry-forward |
+| `languages/` | Translation assets and generated POT file | Work touches strings or i18n packaging |
+| `tests/` | PHPUnit tests, fixtures, PHP test support | You are adding or updating automated coverage |
+| `e2e-tests/` | Browser tests and wp-env config | You need end-to-end verification |
+| `bin/` | Distribution/build helpers | You are adjusting packaging/release behavior |
+
+## Notes & Gotchas
+
+- `yarn run build` is not purely a frontend build; it also tries to generate translations through Docker.
+- Asset builds generate paired RTL files explicitly through `rtlcss:*` scripts.
+- REST and AJAX are both used in this plugin, so editor/import bugs may cross PHP and React boundaries.
+- Builder-specific behavior is split between PHP integration classes in `includes/` and separate app folders (`editor/`, `elementor/`, `beaver/`, `onboarding/`, `assets/`).

--- a/e2e-tests/specs/onboarding.spec.js
+++ b/e2e-tests/specs/onboarding.spec.js
@@ -6,6 +6,24 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 test.describe('Onboarding', () => {
     const ONBOARDING_URL = 'themes.php?page=neve-onboarding';
 
+    const waitForStarterData = ( page ) =>
+        page.waitForResponse(
+            ( response ) =>
+                response.url().includes('/wp-json/ti-demo-data/data') &&
+                response.status() === 200,
+            { timeout: 45000 }
+        );
+
+    const openFirstSiteAndWaitForData = async ( page ) => {
+        const starterDataResponse = waitForStarterData( page );
+        await page.locator('.ss-card-wrap').first().click();
+        await starterDataResponse;
+        await page.waitForSelector('.ob-site-settings.fetching', {
+            state: 'hidden',
+        });
+        await expect(page.locator('.ob-error-wrap')).toHaveCount(0);
+    };
+
     test('Sub-menu in Admin page', async ({ page, admin }) => {
         await admin.visitAdminPage('/');
 
@@ -81,10 +99,7 @@ test.describe('Onboarding', () => {
 
     test('Site Import Customization Rendering', async ({ page, admin }) => {
         await admin.visitAdminPage(ONBOARDING_URL);
-
-        await page.locator('.ss-card-wrap').first().click();
-
-        await page.waitForSelector('.ob-site-settings.fetching', { state: 'hidden' });
+        await openFirstSiteAndWaitForData( page );
 
         // Customize design step.
         await expect(page.getByRole('button', { name: 'Select or upload image' })).toBeVisible();
@@ -124,8 +139,7 @@ test.describe('Onboarding', () => {
 
     test('Site Import Plugins Rendering', async ({ page, admin }) => {
         await admin.visitAdminPage(ONBOARDING_URL);
-        await page.locator('.ss-card-wrap').first().click();
-        await page.waitForSelector('.ob-site-settings.fetching', { state: 'hidden' });
+        await openFirstSiteAndWaitForData( page );
         await page.getByRole('button', { name: 'Continue' }).click();
 
         expect(await page.locator('.ob-feature-card').count()).toBe(6);
@@ -149,8 +163,7 @@ test.describe('Onboarding', () => {
 
     test('Site Import Process', async ({ page, admin }) => {
         await admin.visitAdminPage(ONBOARDING_URL);
-        await page.locator('.ss-card-wrap').first().click();
-        await page.waitForSelector('.ob-site-settings.fetching', { state: 'hidden' });
+        await openFirstSiteAndWaitForData( page );
         await page.getByRole('button', { name: 'Continue' }).click();
         const cachePlugin = page.getByRole('checkbox', { name: 'Caching Supercharge your site' });
         await cachePlugin.click();
@@ -165,8 +178,8 @@ test.describe('Onboarding', () => {
         await page.waitForSelector('.ob-import-done', { timeout: 60000 });
 
         await expect(page.getByRole('textbox', { name: 'Enter your email' })).toBeVisible();
-        await expect(page.locator('#inspector-select-control-0')).toBeVisible(); // User experience selector.
-        await expect(page.locator('#inspector-select-control-1')).toBeVisible(); // Reason the build selector.
+        await expect(page.locator('#inspector-select-control-1')).toBeVisible(); // User experience selector.
+        await expect(page.locator('#inspector-select-control-2')).toBeVisible(); // Reason the build selector.
 
         await expect(page.getByRole('button', { name: 'Submit and view site' })).toBeVisible();
         await expect(page.getByRole('button', { name: 'Skip and view site' })).toBeVisible();
@@ -179,8 +192,7 @@ test.describe('Onboarding', () => {
 
     test( 'Back Button navigation', async ({ page, admin }) => {
         await admin.visitAdminPage(ONBOARDING_URL);
-        await page.locator('.ss-card-wrap').first().click();
-        await page.waitForSelector('.ob-site-settings.fetching', { state: 'hidden' });
+        await openFirstSiteAndWaitForData( page );
         await page.getByRole('button', { name: 'Continue' }).click();
 
         await page.getByRole('button', { name: 'Go back' }).click();
@@ -191,8 +203,7 @@ test.describe('Onboarding', () => {
 
     test( 'Exit from Site Import Steps', async ({ page, admin }) => {
         await admin.visitAdminPage(ONBOARDING_URL);
-        await page.locator('.ss-card-wrap').first().click();
-        await page.waitForSelector('.ob-site-settings.fetching', { state: 'hidden' });
+        await openFirstSiteAndWaitForData( page );
         await page.getByRole('button', { name: 'Continue' }).click();
 
         await page.locator('button:has(span.dashicons-no-alt)' ).click();

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -138,6 +138,87 @@ class Rest_Server {
 				},
 			)
 		);
+
+		register_rest_route(
+			Main::API_ROOT,
+			'/starter_order',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_starter_order' ),
+				'args'                => array(
+					'builder' => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+				),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+
+		register_rest_route(
+			Main::API_ROOT,
+			'/starter_search',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_starter_search' ),
+				'args'                => array(
+					'q'       => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'builder' => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+				),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+	}
+
+	/**
+	 * AI semantic search over the starter-site catalog.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_starter_search( WP_REST_Request $request ) {
+		$builder = $request->get_param( 'builder' );
+		$builder = ( 'elementor' === $builder ) ? 'elementor' : 'gutenberg';
+		$query   = (string) $request->get_param( 'q' );
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'builder' => $builder,
+				'order'   => Starter_Ranking::search( $query, $builder ),
+			)
+		);
+	}
+
+	/**
+	 * Return the personalized starter-site order for a builder.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_starter_order( WP_REST_Request $request ) {
+		$builder = $request->get_param( 'builder' );
+		$builder = ( 'elementor' === $builder ) ? 'elementor' : 'gutenberg';
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'builder' => $builder,
+				'order'   => Starter_Ranking::get_order( $builder ),
+			)
+		);
 	}
 
 	public function run_cleanup() {

--- a/includes/Sites_Listing.php
+++ b/includes/Sites_Listing.php
@@ -35,6 +35,7 @@ class Sites_Listing {
 	 * Initialize the Class.
 	 */
 	public function init() {
+		// Personalization is applied on the client via /starter_order.
 		$this->onboarding_config = array(
 			'remote'      => $this->get_sites(),
 			'upsell'      => array(),

--- a/includes/Starter_Ranking.php
+++ b/includes/Starter_Ranking.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Personalized starter-site ordering.
+ *
+ * @package templates-patterns-collection
+ */
+
+namespace TIOB;
+
+/**
+ * Class Starter_Ranking
+ */
+class Starter_Ranking {
+
+	const DEFAULT_BASE    = 'https://ai.themeisle.com';
+	const SLUG            = 'neve-starter-ranking';
+	const VERSION         = 'v2';
+	const CACHE_TTL       = 7 * DAY_IN_SECONDS;
+	const REQUEST_BUDGET  = 6;
+	const SEARCH_BUDGET   = 8;
+
+	private static function base_url() {
+		if ( defined( 'TPC_AI_PROXY_URL' ) && ! empty( TPC_AI_PROXY_URL ) ) {
+			return rtrim( TPC_AI_PROXY_URL, '/' );
+		}
+
+		return rtrim( apply_filters( 'tpc_ai_proxy_url', self::DEFAULT_BASE ), '/' );
+	}
+
+	private static function cache_key( $builder ) {
+		return 'tpc_starter_order_' . self::VERSION . '_' . $builder;
+	}
+
+	public static function get_order( $builder ) {
+		$builder = ( 'elementor' === $builder ) ? 'elementor' : 'gutenberg';
+
+		return self::cached_order(
+			self::cache_key( $builder ),
+			static function () use ( $builder ) {
+				return self::fetch_order( $builder );
+			},
+			self::CACHE_TTL
+		);
+	}
+
+	private static function cached_order( $key, callable $fetch, $success_ttl ) {
+		$cached = get_transient( $key );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$lock = $key . '_lock';
+		if ( get_transient( $lock ) ) {
+			return array();
+		}
+
+		set_transient( $lock, 1, 2 * MINUTE_IN_SECONDS );
+
+		try {
+			$order = (array) call_user_func( $fetch );
+		} finally {
+			delete_transient( $lock );
+		}
+
+		set_transient( $key, $order, ! empty( $order ) ? $success_ttl : 2 * MINUTE_IN_SECONDS );
+
+		return $order;
+	}
+
+	public static function search( $query, $builder ) {
+		$query = trim( (string) $query );
+		if ( '' === $query ) {
+			return array();
+		}
+
+		$builder = ( 'elementor' === $builder ) ? 'elementor' : 'gutenberg';
+		$key     = 'tpc_starter_search_' . self::VERSION . '_' . $builder . '_' . md5( strtolower( $query ) );
+
+		return self::cached_order(
+			$key,
+			static function () use ( $builder, $query ) {
+				return self::fetch_order( $builder, $query, self::SEARCH_BUDGET );
+			},
+			6 * HOUR_IN_SECONDS
+		);
+	}
+
+	private static function fetch_order( $builder, $query = null, $budget = null ) {
+		$deadline = time() + ( null !== $budget ? (int) $budget : self::REQUEST_BUDGET );
+		$start    = self::base_url() . '/api/workflows/' . self::SLUG . '/start';
+		$body     = array(
+			'site_url' => home_url(),
+			'builder'  => $builder,
+		);
+
+		if ( null !== $query && '' !== $query ) {
+			$body['query'] = $query;
+		}
+
+		$response = wp_remote_post(
+			$start,
+			array(
+				'timeout' => 5,
+				'headers' => self::headers(),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		$order = self::parse_order( $body );
+		if ( ! empty( $order ) ) {
+			return $order;
+		}
+
+		if ( 200 !== $code && 202 !== $code ) {
+			return array();
+		}
+
+		$workflow_id = is_array( $body ) && ! empty( $body['workflowId'] ) ? $body['workflowId'] : '';
+		if ( '' === $workflow_id ) {
+			return array();
+		}
+
+		return self::poll_order( $workflow_id, $deadline );
+	}
+
+	private static function poll_order( $workflow_id, $deadline = null ) {
+		$deadline   = null !== $deadline ? (int) $deadline : ( time() + self::REQUEST_BUDGET );
+		$status_url = self::base_url() . '/api/workflows/' . self::SLUG . '/' . rawurlencode( $workflow_id );
+
+		while ( time() < $deadline ) {
+			usleep( 600000 );
+
+			$remaining = $deadline - time();
+			if ( $remaining <= 0 ) {
+				break;
+			}
+
+			$response = wp_remote_get(
+				$status_url,
+				array(
+					'timeout' => min( 5, $remaining ),
+					'headers' => self::headers(),
+				)
+			);
+			if ( is_wp_error( $response ) ) {
+				continue;
+			}
+
+			$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+			$status = is_array( $body ) && isset( $body['status'] ) ? $body['status'] : '';
+
+			if ( 'completed' === $status ) {
+				return self::parse_order( $body );
+			}
+
+			if ( 'failed' === $status ) {
+				return array();
+			}
+		}
+
+		return array();
+	}
+
+	private static function headers() {
+		$headers = array(
+			'Content-Type' => 'application/json',
+			'Accept'       => 'application/json',
+			'X-Site-Url'   => home_url(),
+		);
+
+		$license = apply_filters( 'tiob_license_key', 'free' );
+		if ( is_string( $license ) && '' !== $license && 'free' !== $license ) {
+			$headers['Authorization'] = 'Bearer ' . base64_encode( $license );
+		}
+
+		return $headers;
+	}
+
+	public static function parse_order( $body ) {
+		if ( ! is_array( $body ) ) {
+			return array();
+		}
+
+		$output = array();
+		if ( isset( $body['output'] ) ) {
+			if ( is_array( $body['output'] ) ) {
+				$output = $body['output'];
+			} elseif ( is_string( $body['output'] ) ) {
+				$decoded_output = json_decode( $body['output'], true );
+				if ( is_array( $decoded_output ) ) {
+					$output = $decoded_output;
+				}
+			}
+		}
+
+		$order = array();
+		if ( isset( $output['order'] ) && is_array( $output['order'] ) ) {
+			$order = $output['order'];
+		} elseif ( isset( $body['order'] ) && is_array( $body['order'] ) ) {
+			$order = $body['order'];
+		}
+
+		return array_values( array_filter( array_map( 'strval', $order ) ) );
+	}
+}

--- a/includes/Starter_Ranking.php
+++ b/includes/Starter_Ranking.php
@@ -12,12 +12,12 @@ namespace TIOB;
  */
 class Starter_Ranking {
 
-	const DEFAULT_BASE    = 'https://ai.themeisle.com';
-	const SLUG            = 'neve-starter-ranking';
-	const VERSION         = 'v2';
-	const CACHE_TTL       = 7 * DAY_IN_SECONDS;
-	const REQUEST_BUDGET  = 6;
-	const SEARCH_BUDGET   = 8;
+	const DEFAULT_BASE   = 'https://ai.themeisle.com';
+	const SLUG           = 'neve-starter-ranking';
+	const VERSION        = 'v2';
+	const CACHE_TTL      = 7 * DAY_IN_SECONDS;
+	const REQUEST_BUDGET = 6;
+	const SEARCH_BUDGET  = 8;
 
 	private static function base_url() {
 		if ( defined( 'TPC_AI_PROXY_URL' ) && ! empty( TPC_AI_PROXY_URL ) ) {

--- a/onboarding/src/Components/CategoryButtons.js
+++ b/onboarding/src/Components/CategoryButtons.js
@@ -1,65 +1,46 @@
-/* global tiobDash */
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
-import { track } from '../utils/rest';
 import { useMemo, useEffect } from '@wordpress/element';
 
 const CategoryButtons = ( { categories, style } ) => {
 	const data = useSelect( ( select ) => ( {
 		category: select( 'ti-onboarding' ).getCurrentCategory(),
-		query: select( 'ti-onboarding' ).getSearchQuery(),
-		trackingId: select( 'ti-onboarding' ).getTrackingId(),
-		step: select( 'ti-onboarding' ).getCurrentStep(),
 		sitesMetadata: select( 'ti-onboarding' ).getSites(),
 		editor: select( 'ti-onboarding' ).getCurrentEditor(),
 	} ) );
 
-	const { setOnboardingStep, setCategory } = useDispatch( 'ti-onboarding' );
+	const { setCategory } = useDispatch( 'ti-onboarding' );
 
-	const availableCategories = useMemo(() => {
-		return Object.keys(categories).filter((key) => 
-			// Show "All" and "Free" categories after user selection.
-			data.category || (key !== 'all' && key !== 'free')
-		).filter((key) => {
-			// Hide "Free" is there is not free template available on the selected editor.
-			if ( key !== 'free' ) {
-				return true;
-			}
-			return Object.values(data.sitesMetadata.sites?.[data.editor])?.some( (s) => ! s?.upsell);
-		});
-	}, [categories, data.category, data.sitesMetadata, data.editor]);
+	const availableCategories = useMemo( () => {
+		return Object.keys( categories )
+			.filter(
+				( key ) =>
+					// Show "All" and "Free" categories after user selection.
+					data.category || ( key !== 'all' && key !== 'free' )
+			)
+			.filter( ( key ) => {
+				// Hide "Free" is there is not free template available on the selected editor.
+				if ( key !== 'free' ) {
+					return true;
+				}
+				return Object.values( data.sitesMetadata.sites?.[ data.editor ] )?.some(
+					( site ) => ! site?.upsell
+				);
+			} );
+	}, [ categories, data.category, data.sitesMetadata, data.editor ] );
 
 	const onClick = ( newCategory ) => {
 		setCategory( newCategory );
-
-		if ( data.step === 1 ) {
-			setOnboardingStep( 2 );
-
-			const trackData = {
-				slug: 'neve',
-				license_id: tiobDash.license,
-				site: tiobDash.onboarding.homeUrl || '',
-				search: data.query,
-				cat: newCategory,
-				step_id: 1,
-				step_status: 'completed',
-			};
-
-			track( data.trackingId, trackData ).catch( ( error ) => {
-				// eslint-disable-next-line no-console
-				console.error( error );
-			} );
-		}
 	};
 
 	/**
 	 * Default the category to 'all' when the current category is unavailable.
 	 */
-	useEffect(() => {
-		if (data.category && !availableCategories.includes(data.category)) {
-			setCategory('all');
+	useEffect( () => {
+		if ( data.category && ! availableCategories.includes( data.category ) ) {
+			setCategory( 'all' );
 		}
-	}, [data.category, availableCategories, setCategory]);
+	}, [ data.category, availableCategories, setCategory ] );
 
 	return (
 		<div className="ob-cat-wrap" style={ style }>

--- a/onboarding/src/Components/Filters.js
+++ b/onboarding/src/Components/Filters.js
@@ -1,19 +1,235 @@
 import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import Search from './Search';
 import CategoryButtons from './CategoryButtons';
 import { ONBOARDING_CAT } from '../utils/common';
 
+const hashColor = ( value = '' ) => {
+	let hash = 0;
+	for ( let index = 0; index < value.length; index++ ) {
+		hash = value.charCodeAt( index ) + ( ( hash << 5 ) - hash );
+	}
+
+	return Math.abs( hash );
+};
+
+const swatchBackground = ( colorSlug = '' ) => {
+	const normalized = String( colorSlug ).trim().toLowerCase();
+	if ( ! normalized ) {
+		return 'linear-gradient(135deg, #cbd5e1 0%, #64748b 100%)';
+	}
+
+	if (
+		/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test( normalized ) ||
+		/^(rgb|rgba|hsl|hsla)\(/i.test( normalized )
+	) {
+		return normalized;
+	}
+
+	if (
+		typeof window !== 'undefined' &&
+		window.CSS &&
+		typeof window.CSS.supports === 'function' &&
+		window.CSS.supports( 'color', normalized )
+	) {
+		return normalized;
+	}
+
+	const hue = hashColor( normalized ) % 360;
+	const hueShift = ( hue + 24 ) % 360;
+
+	return `linear-gradient(135deg, hsl(${ hue } 72% 72%) 0%, hsl(${ hueShift } 72% 44%) 100%)`;
+};
+
 const Filters = () => {
+	const [ isColorOpen, setIsColorOpen ] = useState( false );
+	const colorFilterRef = useRef( null );
+	const { sortBy, searchQuery, editor, sites, selectedColors } = useSelect( ( select ) => ( {
+		sortBy: select( 'ti-onboarding' ).getSortBy(),
+		searchQuery: select( 'ti-onboarding' ).getSearchQuery(),
+		editor: select( 'ti-onboarding' ).getCurrentEditor(),
+		sites: select( 'ti-onboarding' ).getSites(),
+		selectedColors: select( 'ti-onboarding' ).getSelectedColors(),
+	} ) );
+	const { setSortBy, setSelectedColors } = useDispatch( 'ti-onboarding' );
+
 	const categories = {
 		all: __( 'All', 'templates-patterns-collection' ),
 		free: __( 'Free', 'templates-patterns-collection' ),
 		...ONBOARDING_CAT,
 	};
 
+	const trimmed = ( searchQuery || '' ).trim();
+	const showHint =
+		trimmed.length > 0 && trimmed.length <= 12 && ! trimmed.includes( ' ' );
+	const availableColors = useMemo( () => {
+		const builderSites = Object.values( sites?.sites?.[ editor ] || {} );
+		const seen = new Set();
+		const colors = [];
+
+		builderSites.forEach( ( site ) => {
+			if ( ! Array.isArray( site?.colors ) ) {
+				return;
+			}
+
+			site.colors.forEach( ( color ) => {
+				const normalized = String( color || '' ).trim().toLowerCase();
+				if ( ! normalized || seen.has( normalized ) ) {
+					return;
+				}
+
+				seen.add( normalized );
+				colors.push( normalized );
+			} );
+		} );
+
+		return colors;
+	}, [ sites, editor ] );
+	const sortOptions = [
+		{
+			label: __( 'Recommended', 'templates-patterns-collection' ),
+			value: 'recommended',
+		},
+		{
+			label: __( 'Popular', 'templates-patterns-collection' ),
+			value: 'popular',
+		},
+		...( editor === 'gutenberg'
+			? [
+					{
+						label: __( 'New first', 'templates-patterns-collection' ),
+						value: 'new',
+					},
+			  ]
+			: [] ),
+	];
+
+	useEffect( () => {
+		if ( ! isColorOpen ) {
+			return undefined;
+		}
+
+		const handleOutsideClick = ( event ) => {
+			if ( colorFilterRef.current?.contains( event.target ) ) {
+				return;
+			}
+
+			setIsColorOpen( false );
+		};
+
+		document.addEventListener( 'mousedown', handleOutsideClick );
+
+		return () => {
+			document.removeEventListener( 'mousedown', handleOutsideClick );
+		};
+	}, [ isColorOpen ] );
+
 	return (
-		<div className="ob-filters-container">
-			<Search />
-			<CategoryButtons categories={ categories } />
+		<div className="ob-filters">
+			<div className="ob-search-row">
+				<Search
+					placeholder={ __(
+						'Describe your site — e.g. "law firm for personal injury cases"',
+						'templates-patterns-collection'
+					) }
+				/>
+				{ showHint && (
+					<p className="ob-search-hint">
+						{ __(
+							'Add a detail or two for sharper matches — try what you do, who it\'s for, or where.',
+							'templates-patterns-collection'
+						) }
+					</p>
+				) }
+			</div>
+			<div className="ob-filters-bar">
+				<CategoryButtons categories={ categories } />
+				{ availableColors.length > 0 && (
+					<div
+						ref={ colorFilterRef }
+						className={
+							isColorOpen ? 'ob-color-filter is-open' : 'ob-color-filter'
+						}
+					>
+						<button
+							type="button"
+							className={
+								selectedColors.length
+									? 'ob-color-filter__trigger has-selection'
+									: 'ob-color-filter__trigger'
+							}
+							aria-expanded={ isColorOpen }
+							onClick={ () => setIsColorOpen( ( open ) => ! open ) }
+						>
+							<span className="ob-color-filter__wheel" aria-hidden="true" />
+							<span className="ob-color-filter__label">
+								{ selectedColors.length
+									? `${ selectedColors.length } ${ __(
+											'selected',
+											'templates-patterns-collection'
+									  ) }`
+									: __( 'Color', 'templates-patterns-collection' ) }
+							</span>
+							<span className="ob-color-filter__chevron" aria-hidden="true">
+								▾
+							</span>
+						</button>
+						<div className="ob-color-filter__panel">
+							{ availableColors.map( ( color ) => (
+								<button
+									type="button"
+									key={ color }
+									className={
+										selectedColors.includes( color )
+											? 'ob-color-filter__option is-active'
+											: 'ob-color-filter__option'
+									}
+									onClick={ () => {
+										setSelectedColors(
+											selectedColors.includes( color )
+												? selectedColors.filter( ( item ) => item !== color )
+												: [ ...selectedColors, color ]
+										);
+									} }
+								>
+									<span
+										className="ob-color-filter__swatch"
+										style={ {
+											background: swatchBackground( color ),
+										} }
+									/>
+									<span className="ob-color-filter__name">{ color }</span>
+								</button>
+							) ) }
+							{ selectedColors.length > 0 && (
+								<button
+									type="button"
+									className="ob-color-filter__clear"
+									onClick={ () => {
+										setSelectedColors( [] );
+										setIsColorOpen( false );
+									} }
+								>
+									{ __( 'Clear', 'templates-patterns-collection' ) }
+								</button>
+							) }
+						</div>
+					</div>
+				) }
+				<SelectControl
+					className="ob-sort-select"
+					label={ __( 'Sort', 'templates-patterns-collection' ) }
+					hideLabelFromVision
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					value={ searchQuery ? 'recommended' : sortBy }
+					options={ sortOptions }
+					onChange={ setSortBy }
+					disabled={ !! searchQuery }
+				/>
+			</div>
 		</div>
 	);
 };

--- a/onboarding/src/Components/Header.js
+++ b/onboarding/src/Components/Header.js
@@ -88,7 +88,7 @@ export default compose(
 		const { setOnboardingStep } = dispatch( 'ti-onboarding' );
 		return {
 			handleLogoClick: () => {
-				setOnboardingStep( 1 );
+				setOnboardingStep( 2 );
 			},
 		};
 	} )

--- a/onboarding/src/Components/Onboarding.js
+++ b/onboarding/src/Components/Onboarding.js
@@ -1,7 +1,6 @@
 import { Fragment, useState } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import Header from './Header';
-import Welcome from './Steps/Welcome';
 import SiteList from './Steps/SiteList';
 import CustomizeSite from './Steps/CustomizeSite';
 
@@ -23,7 +22,6 @@ const Onboarding = ( { step, themeData } ) => {
 	return (
 		<Fragment>
 			{ ! isPreviewStep && <Header importing={ importing } /> }
-			{ step === 1 && <Welcome /> }
 			{ step === 2 && (
 				<SiteList
 					showToast={ showToast }

--- a/onboarding/src/Components/Search.js
+++ b/onboarding/src/Components/Search.js
@@ -13,6 +13,7 @@ const Search = ( {
 	step,
 	deleteQuery,
 	label,
+	placeholder,
 } ) => {
 	return (
 		<form onSubmit={ handleSubmit } className="ob-search-form">
@@ -23,6 +24,7 @@ const Search = ( {
 					id="ob-search-ss"
 					type="text"
 					value={ query }
+					placeholder={ placeholder }
 					onChange={ ( e ) => {
 						onSearch( e.target.value );
 					} }

--- a/onboarding/src/Components/Sites.js
+++ b/onboarding/src/Components/Sites.js
@@ -1,199 +1,286 @@
-import { useState } from '@wordpress/element';
+import { Fragment, useEffect, useMemo, useState } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import StarterSiteCard from './StarterSiteCard';
 import VizSensor from 'react-visibility-sensor';
-import Fuse from 'fuse.js/dist/fuse.min';
+import { matchesCategory, searchCatalog } from '../utils/search';
 
 /**
  * @typedef {Object} Site
- * @property {string}   url        - The demo site URL
- * @property {string}   remote_url - The API endpoint URL
- * @property {string}   screenshot - The screenshot image URL
- * @property {string}   title      - The site title
- * @property {string[]} keywords   - Array of keyword strings
- * @property {boolean}  isNew      - Whether the site is new
- * @property {string}   slug       - The site's slug
+ * @property {string}   url
+ * @property {string}   remote_url
+ * @property {string}   screenshot
+ * @property {string}   title
+ * @property {string[]} keywords
+ * @property {boolean}  isNew
+ * @property {string}   slug
  */
 
-
-const MINIMUM_SITES_LISTING = 10;
-
-const Sites = ( { getSites, editor, category, searchQuery } ) => {
+const Sites = ( {
+	getSites,
+	editor,
+	category,
+	searchQuery,
+	rankedOrder,
+	searchOrder,
+	searchFailed,
+	sortBy,
+	selectedColors,
+} ) => {
 	const [ maxShown, setMaxShown ] = useState( 9 );
 	const { sites = {} } = getSites;
 
-	const getFilteredSites = () => {
-		const allSites = getAllSites();
-		if ( Object.keys( allSites ).length === 0 ) {
-			return [];
-		}
+	useEffect( () => {
+		setMaxShown( 9 );
+	}, [ editor, category, searchQuery, sortBy, selectedColors ] );
 
-		/** @type {Site[]} */
-		let builderSites = allSites[ editor ];
-		const sitesBySearch = filterBySearch( builderSites );
-		builderSites = filterByCategory( sitesBySearch, category );
+	const getBuilders = () => Object.keys( sites );
 
-		if ( MINIMUM_SITES_LISTING > builderSites.length ) {
-			// Populate with sites related to search.
-			for (const site of sitesBySearch) {
-				if (builderSites.length >= MINIMUM_SITES_LISTING) {
-					break;
-				}
-				if (builderSites.find(existing => existing.slug === site.slug)) {
-					continue;
-				}
-				if (site?.upsell && 'free' === category) {
-					continue;
-				}
-				builderSites.push(site);
-			}
-			
-			// Get the top recommendation if we still do not meed the minimum.
-			for (const site of allSites[editor]) {
-				if (builderSites.length >= MINIMUM_SITES_LISTING) {
-					break;
-				}
-				if (builderSites.find(existing => existing.slug === site.slug)) {
-					continue;
-				}
-				if (site?.upsell && 'free' === category) {
-					continue;
-				}
-				builderSites.push(site);
-			}
-		}
-		
-		return builderSites;
-	};
-	
 	const getAllSites = () => {
 		const finalData = {};
 		const builders = getBuilders();
 
 		builders.forEach( ( builder ) => {
 			const sitesData = sites && sites[ builder ] ? sites[ builder ] : {};
-			finalData[ builder ] = [ ...Object.values( sitesData ) ];
+			finalData[ builder ] = Object.entries( sitesData ).map(
+				( [ slug, site ] ) => ( { ...site, slug } )
+			);
 		} );
 
 		return finalData;
 	};
 
-	/**
-	 * Sort the sites based on keyword position.
-	 *
-	 * @param {string} keyword     The keyword.
-	 * @param {Site[]} sitesToSort The list of sites to sort.
-	 *
-	 * @return {Site[]} Array of sites sorted by keyword position.
-	 */
-	const sortByKeywords = (keyword, sitesToSort) => {
-		const _keyword = keyword?.toLowerCase();
-		return sitesToSort.sort((a, b) => {
-			if (!Array.isArray(a?.keywords) || !Array.isArray(b?.keywords)) {
+	const pickBySlugs = ( siteList, slugs ) => {
+		if ( ! Array.isArray( siteList ) || ! Array.isArray( slugs ) ) {
+			return { picked: [], placed: {} };
+		}
+
+		const bySlug = new Map(
+			siteList
+				.filter( ( site ) => site && site.slug )
+				.map( ( site ) => [ site.slug, site ] )
+		);
+		const picked = [];
+		const placed = {};
+
+		slugs.forEach( ( slug ) => {
+			if ( ! slug || placed[ slug ] || ! bySlug.has( slug ) ) {
+				return;
+			}
+
+			placed[ slug ] = true;
+			picked.push( bySlug.get( slug ) );
+		} );
+
+		return { picked, placed };
+	};
+
+	const applyRanking = ( sitesToRank, order ) => {
+		if ( ! Array.isArray( order ) || ! order.length ) {
+			return sitesToRank;
+		}
+
+		const { picked, placed } = pickBySlugs( sitesToRank, order );
+		sitesToRank.forEach( ( site ) => {
+			if ( site && ( ! site.slug || ! placed[ site.slug ] ) ) {
+				picked.push( site );
+			}
+		} );
+
+		return picked;
+	};
+
+	const applySort = ( list, mode, fullList ) => {
+		const rowIndex = new Map(
+			fullList.map( ( site, index ) => [ site.slug, index ] )
+		);
+		const byRow = ( a, b ) =>
+			( rowIndex.get( a.slug ) ?? Number.MAX_SAFE_INTEGER ) -
+			( rowIndex.get( b.slug ) ?? Number.MAX_SAFE_INTEGER );
+
+		if ( mode === 'new' ) {
+			return [ ...list ].sort(
+				( a, b ) =>
+					( b.isNew ? 1 : 0 ) - ( a.isNew ? 1 : 0 ) || byRow( a, b )
+			);
+		}
+
+		return [ ...list ].sort( byRow );
+	};
+
+	const sortByKeywords = ( keyword, sitesToSort ) => {
+		const normalizedKeyword = keyword?.toLowerCase();
+
+		return sitesToSort.sort( ( a, b ) => {
+			const aHasKeywords = Array.isArray( a?.keywords );
+			const bHasKeywords = Array.isArray( b?.keywords );
+
+			if ( ! aHasKeywords && ! bHasKeywords ) {
 				return 0;
 			}
-
-			const aHasKeyword = a.keywords.includes(_keyword);
-			const bHasKeyword = b.keywords.includes(_keyword);
-
-			if (aHasKeyword && !bHasKeyword) {
+			if ( ! aHasKeywords ) {
+				return 1;
+			}
+			if ( ! bHasKeywords ) {
 				return -1;
 			}
-			if (!aHasKeyword && bHasKeyword) {
+
+			const aHasKeyword = a.keywords.includes( normalizedKeyword );
+			const bHasKeyword = b.keywords.includes( normalizedKeyword );
+
+			if ( aHasKeyword && ! bHasKeyword ) {
+				return -1;
+			}
+			if ( ! aHasKeyword && bHasKeyword ) {
 				return 1;
 			}
 
-			const aIndex = a.keywords.findIndex(k => k === _keyword);
-			const bIndex = b.keywords.findIndex(k => k === _keyword);
+			const aIndex = a.keywords.findIndex( ( value ) => value === normalizedKeyword );
+			const bIndex = b.keywords.findIndex( ( value ) => value === normalizedKeyword );
+
 			return aIndex - bIndex;
-		});
+		} );
 	};
-	
-	/**
-	 * Filters an array of items based on a search query using Fuse.js for fuzzy searching.
-	 *
-	 * @param {Site[]} items Array of objects containing title, slug, and keywords properties to search through
-	 * @return {Site[]} Filtered array of items that match the search query, or the original array if no query
-	 */
+
 	const filterBySearch = ( items ) => {
 		if ( ! searchQuery ) {
 			return items;
 		}
-		
-		const fuse = new Fuse(items, {
-			includeScore: true,
-			keys: [
-				{
-					name: 'title',
-					weight: 0.5
-				},
-				{
-					name: 'slug',
-					weight: 0.1
-				},
-				{
-					name: 'keywords',
-					weight: 0.4,
-				}
-			],
-			threshold: 0.4
-		});
 
-		const fuzzyResults = fuse.search(searchQuery)
-			.map(result => result.item)
-			.filter(Boolean);
+		if ( Array.isArray( searchOrder ) && searchOrder.length ) {
+			return pickBySlugs( items, searchOrder ).picked;
+		}
 
-		return sortByKeywords( searchQuery, fuzzyResults );
+		if ( searchFailed ) {
+			return searchCatalog( items, searchQuery );
+		}
+
+		return [];
 	};
 
-	/**
-	 * Filters an array of items based on a category.
-	 * @param {Site[]} items The array of items to filter.
-	 * @param {string} cat   The category to filter by. Can be 'free', 'all', or any other category value.
-	 * @return {Site[]} A filtered array of items based on the category.
-	 */
 	const filterByCategory = ( items, cat ) => {
 		if ( 'free' === cat ) {
-			return items.filter( ( item ) => ! item.upsell );
+			return items.filter( ( item ) => matchesCategory( item, cat ) );
 		}
 
 		if ( cat && 'all' !== cat ) {
-			const filteredByCat = items.filter( ( item ) => {
-				if (!Array.isArray(item?.keywords)) {
-					return false;
-				}
-				const keywordIndex = item.keywords.findIndex(k => k === cat);
-				return keywordIndex !== -1;
-			});
-			return sortByKeywords( cat, filteredByCat ); 
+			const filteredByCat = items.filter( ( item ) =>
+				matchesCategory( item, cat )
+			);
+
+			return sortByKeywords( cat, filteredByCat );
 		}
 
 		return items;
 	};
 
-	const getBuilders = () => Object.keys( sites );
+	const filterByColors = ( items ) => {
+		if ( ! Array.isArray( selectedColors ) || ! selectedColors.length ) {
+			return items;
+		}
 
-	const allData = getFilteredSites();
+		return items.filter( ( site ) => {
+			if ( ! Array.isArray( site?.colors ) || ! site.colors.length ) {
+				return false;
+			}
+
+			const siteColors = site.colors.map( ( color ) =>
+				String( color || '' ).trim().toLowerCase()
+			);
+
+			return selectedColors.some( ( color ) => siteColors.includes( color ) );
+		} );
+	};
+
+	const getFilteredSites = () => {
+		const allSites = getAllSites();
+		if ( Object.keys( allSites ).length === 0 ) {
+			return { list: [], matchCount: 0 };
+		}
+
+		const fullBucket = allSites[ editor ] || [];
+		let ranked = fullBucket;
+		if ( searchQuery || ! sortBy || sortBy === 'recommended' ) {
+			ranked = applyRanking( fullBucket, rankedOrder && rankedOrder[ editor ] );
+		}
+
+		if ( searchQuery ) {
+			const matches = filterByColors(
+				filterByCategory( filterBySearch( ranked ), category )
+			);
+			const inMatches = {};
+			matches.forEach( ( site ) => {
+				if ( site && site.slug ) {
+					inMatches[ site.slug ] = true;
+				}
+			} );
+
+			const rest = filterByColors( filterByCategory( ranked, category ) ).filter(
+				( site ) => site && site.slug && ! inMatches[ site.slug ]
+			);
+			const remainder = matches.length % 3;
+			const pad =
+				remainder === 0 ? 0 : Math.min( 3 - remainder, rest.length );
+
+			return {
+				list: [ ...matches, ...rest ],
+				matchCount: matches.length + pad,
+			};
+		}
+
+		let builderSites = filterByColors( filterByCategory( ranked, category ) );
+		if ( sortBy === 'popular' || sortBy === 'new' ) {
+			builderSites = applySort( builderSites, sortBy, fullBucket );
+		}
+
+		return { list: builderSites, matchCount: 0 };
+	};
+
+	const { list: allData, matchCount } = useMemo(
+		() => getFilteredSites(),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[
+			sites,
+			editor,
+			category,
+			searchQuery,
+			sortBy,
+			selectedColors,
+			rankedOrder,
+			searchOrder,
+			searchFailed,
+		]
+	);
+
 	return (
 		<>
 			{ allData.length ? (
 				<div className="ob-sites is-grid">
-					{ allData.slice( 0, maxShown ).map( ( site, index ) => {
-						return (
-							<StarterSiteCard
-								key={ index }
-								data={ site }
-							/>
-						);
-					} ) }
+					{ allData.slice( 0, maxShown ).map( ( site, index ) => (
+						<Fragment key={ site.slug || index }>
+							{ searchQuery &&
+								matchCount > 0 &&
+								index === matchCount && (
+									<div className="ob-results-divider">
+										<span>
+											{ __(
+												'Not quite right? Browse more',
+												'templates-patterns-collection'
+											) }
+										</span>
+									</div>
+								) }
+							<StarterSiteCard data={ site } />
+						</Fragment>
+					) ) }
 
 					<VizSensor
 						onChange={ ( isVisible ) => {
 							if ( ! isVisible ) {
 								return false;
 							}
-							setMaxShown( maxShown + 9 );
+
+							setMaxShown( ( shown ) => shown + 9 );
 						} }
 					>
 						<span
@@ -205,7 +292,7 @@ const Sites = ( { getSites, editor, category, searchQuery } ) => {
 						/>
 					</VizSensor>
 				</div>
-			) : (
+			) : searchQuery && ! searchFailed && ! searchOrder.length ? null : (
 				<div className="ob-no-results">
 					<p>
 						{ __(
@@ -225,12 +312,27 @@ const Sites = ( { getSites, editor, category, searchQuery } ) => {
 };
 
 export default withSelect( ( select ) => {
-	const { getCurrentEditor, getCurrentCategory, getSites, getSearchQuery } =
-		select( 'ti-onboarding' );
+	const {
+		getCurrentEditor,
+		getCurrentCategory,
+		getSites,
+		getSearchQuery,
+		getRankedOrder,
+		getSearchOrder,
+		getSearchFailed,
+		getSortBy,
+		getSelectedColors,
+	} = select( 'ti-onboarding' );
+
 	return {
 		editor: getCurrentEditor(),
 		category: getCurrentCategory(),
 		searchQuery: getSearchQuery(),
 		getSites: getSites(),
+		rankedOrder: getRankedOrder(),
+		searchOrder: getSearchOrder(),
+		searchFailed: getSearchFailed(),
+		sortBy: getSortBy(),
+		selectedColors: getSelectedColors(),
 	};
 } )( Sites );

--- a/onboarding/src/Components/StarterSiteCard.js
+++ b/onboarding/src/Components/StarterSiteCard.js
@@ -1,8 +1,46 @@
 /* global tiobDash */
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { track } from '../utils/rest';
+
+const hashColor = ( value = '' ) => {
+	let hash = 0;
+	for ( let index = 0; index < value.length; index++ ) {
+		hash = value.charCodeAt( index ) + ( ( hash * 32 ) - hash );
+	}
+
+	return Math.abs( hash );
+};
+
+const swatchBackground = ( colorSlug = '' ) => {
+	const normalized = String( colorSlug ).trim().toLowerCase();
+	if ( ! normalized ) {
+		return 'linear-gradient(135deg, #cbd5e1 0%, #64748b 100%)';
+	}
+
+	if (
+		/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test( normalized ) ||
+		/^(rgb|rgba|hsl|hsla)\(/i.test( normalized )
+	) {
+		return normalized;
+	}
+
+	if (
+		typeof window !== 'undefined' &&
+		window.CSS &&
+		typeof window.CSS.supports === 'function' &&
+		window.CSS.supports( 'color', normalized )
+	) {
+		return normalized;
+	}
+
+	const hue = hashColor( normalized ) % 360;
+	const hueShift = ( hue + 24 ) % 360;
+
+	return `linear-gradient(135deg, hsl(${ hue } 72% 72%) 0%, hsl(${ hueShift } 72% 44%) 100%)`;
+};
 
 const StarterSiteCard = ( {
 	data,
@@ -11,10 +49,79 @@ const StarterSiteCard = ( {
 	trackingId,
 	editor
 } ) => {
-	const { upsell, screenshot, title, category, query } = data;
+	const {
+		upsell,
+		screenshot,
+		title,
+		category,
+		query,
+		site_description: siteDescription,
+		description,
+	} = data;
+	const cardDescription = ( siteDescription || description || '' ).trim();
+	const pageShots = useMemo( () => {
+		if ( ! Array.isArray( data?.page_shots ) || ! data.page_shots.length ) {
+			return screenshot
+				? [
+						{
+							key: 'home',
+							label: __( 'Home', 'templates-patterns-collection' ),
+							screenshot,
+						},
+				  ]
+				: [];
+		}
+
+		return data.page_shots
+			.filter( ( shot ) => shot && shot.screenshot )
+			.map( ( shot ) => ( {
+				key: shot.key || shot.label || 'page',
+				label: shot.label || shot.key || __( 'Page', 'templates-patterns-collection' ),
+				screenshot: shot.screenshot,
+			} ) );
+	}, [ data?.page_shots, screenshot ] );
+	const colorOptions = useMemo( () => {
+		const colors = Array.isArray( data?.colors ) ? data.colors.filter( Boolean ) : [];
+		const screenshotMap =
+			data?.screenshots_by_color && typeof data.screenshots_by_color === 'object'
+				? data.screenshots_by_color
+				: {};
+
+		return colors.map( ( color ) => ( {
+			slug: color,
+			label: color.replace( /[-_]/g, ' ' ),
+			screenshot: screenshotMap[ color ] || screenshot,
+		} ) );
+	}, [ data?.colors, data?.screenshots_by_color, screenshot ] );
+	const previewColors = colorOptions.slice( 0, 2 );
+	const [ activePage, setActivePage ] = useState( pageShots[0]?.key || 'home' );
+	const [ activeColor, setActiveColor ] = useState( colorOptions[0]?.slug || '' );
+	const [ isColorExpanded, setIsColorExpanded ] = useState( false );
+
+	useEffect( () => {
+		setActivePage( pageShots[0]?.key || 'home' );
+	}, [ pageShots ] );
+
+	useEffect( () => {
+		setActiveColor( colorOptions[0]?.slug || '' );
+	}, [ colorOptions ] );
+
+	const activePageShot =
+		pageShots.find( ( shot ) => shot.key === activePage ) || pageShots[0] || null;
+	const activeColorOption =
+		colorOptions.find( ( option ) => option.slug === activeColor ) || colorOptions[0] || null;
+	const activeScreenshot =
+		activePage === 'home'
+			? activeColorOption?.screenshot || activePageShot?.screenshot || screenshot
+			: activePageShot?.screenshot || activeColorOption?.screenshot || screenshot;
 
 	const launchPreview = () => {
-		setSite();
+		setSite( {
+			...data,
+			preview_screenshot: activeScreenshot,
+			preview_color: activeColor,
+			preview_page: activePage,
+		} );
 		handleNextStep();
 		const trackData = {
 			slug: 'neve',
@@ -58,16 +165,120 @@ const StarterSiteCard = ( {
 					</span>
 				) }
 
-				{ screenshot && (
+				{ activeScreenshot && (
 					<div
 						className="ss-image"
 						style={ {
-							backgroundImage: `url("${ screenshot }")`,
+							backgroundImage: `url("${ activeScreenshot }")`,
 						} }
-					/>
+					>
+						{ pageShots.length > 1 && (
+							<div className="ss-page-shots">
+								{ pageShots.map( ( shot ) => (
+									<button
+										type="button"
+										key={ shot.key }
+										className={
+											shot.key === activePage
+												? 'ss-page-shot is-active'
+												: 'ss-page-shot'
+										}
+										onClick={ ( event ) => {
+											event.preventDefault();
+											event.stopPropagation();
+											setActivePage( shot.key );
+										} }
+									>
+										{ shot.label }
+									</button>
+								) ) }
+							</div>
+						) }
+						{ colorOptions.length > 0 && (
+							<div
+								className={
+									isColorExpanded
+										? 'ss-color-summary is-expanded'
+										: 'ss-color-summary'
+								}
+								onMouseEnter={ () => setIsColorExpanded( true ) }
+								onMouseLeave={ () => setIsColorExpanded( false ) }
+								onFocus={ () => setIsColorExpanded( true ) }
+								onBlur={ ( event ) => {
+									if ( ! event.currentTarget.contains( event.relatedTarget ) ) {
+										setIsColorExpanded( false );
+									}
+								} }
+							>
+								{ ! isColorExpanded ? (
+									<div className="ss-color-summary__collapsed">
+										<div className="ss-color-summary__swatches">
+											{ previewColors.map( ( option ) => (
+												<span
+													key={ option.slug }
+													className="ss-color-dot"
+													style={ {
+														background: swatchBackground( option.slug ),
+													} }
+													aria-hidden="true"
+													title={ option.label }
+												/>
+											) ) }
+										</div>
+										{ colorOptions.length > 2 && (
+											<span className="ss-color-summary__count">
+												+{ colorOptions.length - 2 }
+											</span>
+										) }
+									</div>
+								) : (
+									<div className="ss-color-summary__expanded">
+										{ colorOptions.map( ( option ) => (
+											<button
+												type="button"
+												key={ option.slug }
+												className={
+													option.slug === activeColor
+														? 'ss-color-swatch is-active'
+														: 'ss-color-swatch'
+												}
+												onClick={ ( event ) => {
+													event.preventDefault();
+													event.stopPropagation();
+													setActiveColor( option.slug );
+												} }
+												aria-label={ sprintf(
+													/* translators: %s is a color label. */
+													__(
+														'Preview %s color',
+														'templates-patterns-collection'
+													),
+													option.label
+												) }
+												title={ option.label }
+											>
+												<span
+													className="ss-color-dot"
+													style={ {
+														background: swatchBackground( option.slug ),
+													} }
+													aria-hidden="true"
+												/>
+											</button>
+										) ) }
+									</div>
+								) }
+							</div>
+						) }
+					</div>
 				) }
 			</div>
-			<p className="ss-title">{ title }</p>
+			<div className="ss-copy">
+				<p className="ss-title">{ title }</p>
+				{ cardDescription && (
+					<p className="ss-description">{ cardDescription }</p>
+				) }
+			</div>
 		</div>
 	);
 };
@@ -91,7 +302,7 @@ export default compose(
 		const { setCurrentSite, setOnboardingStep } =
 			dispatch( 'ti-onboarding' );
 		return {
-			setSite: () => setCurrentSite( data ),
+			setSite: ( nextSite = data ) => setCurrentSite( nextSite ),
 			handleNextStep: () => setOnboardingStep( 3 ),
 		};
 	} )

--- a/onboarding/src/Components/Steps/Import.js
+++ b/onboarding/src/Components/Steps/Import.js
@@ -139,7 +139,11 @@ const Import = ( {
 				}
 				console.log( '[D] Plugins.' );
 				setActionsDone( ( prevActionsDone ) => prevActionsDone + 1 );
-				runImportContent();
+				try {
+					runImportContent();
+				} catch ( incomingError ) {
+					handleError( incomingError, 'content' );
+				}
 			} )
 			.catch( ( incomingError ) =>
 				handleError( incomingError, 'plugins' )
@@ -152,6 +156,12 @@ const Import = ( {
 			runImportCustomizer();
 			return false;
 		}
+
+		if ( ! importData || ! importData.content_file ) {
+			handleError( { data: 'ti__ob_missing_import_data' }, 'content' );
+			return false;
+		}
+
 		setCurrentStep( 'content' );
 		console.log( '[P] Content.' );
 		importContent( {

--- a/onboarding/src/Components/Steps/SiteList.js
+++ b/onboarding/src/Components/Steps/SiteList.js
@@ -1,15 +1,39 @@
 /* global tiobDash */
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement, useEffect } from '@wordpress/element';
-import { withDispatch } from '@wordpress/data';
+import {
+	createInterpolateElement,
+	useEffect,
+	useState,
+} from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
 import Toast from '../Toast';
 import Filters from '../Filters';
 import Sites from '../Sites';
 import EditorSelector from '../EditorSelector';
 import OnboardingPromoNotice from '../OnboardingPromoNotice';
 import SVG from '../../utils/svg';
+import { get, track } from '../../utils/rest';
 
-const SiteList = ( { showToast, setShowToast, setFetching } ) => {
+const { onboarding } = tiobDash;
+
+// Guards tracking-session init against firing twice while the first request is in flight.
+let trackingInitStarted = false;
+
+const SiteList = ( {
+	showToast,
+	setShowToast,
+	editor,
+	searchQuery,
+	trackingId,
+	setTrackingId,
+	setRankedOrder,
+	setSearchOrder,
+	setSearchFailed,
+} ) => {
+	const [ personalizing, setPersonalizing ] = useState( false );
+	const [ searching, setSearching ] = useState( false );
+
 	const toastMessage = createInterpolateElement(
 		__(
 			'Unlock Access to all premium templates with Neve Business plan. <a></a>.',
@@ -28,21 +52,144 @@ const SiteList = ( { showToast, setShowToast, setFetching } ) => {
 		}
 	);
 
-	const handleShowToast = () => {
+	useEffect( () => {
 		if ( showToast === 'dismissed' ) {
 			return;
 		}
 
-		// Automatically hide the toast after a certain duration (e.g., 5 seconds)
-		setTimeout( () => {
+		const timeoutId = setTimeout( () => {
 			setShowToast( true );
 		}, 1000 );
-	};
+
+		if ( trackingId || trackingInitStarted ) {
+			return () => clearTimeout( timeoutId );
+		}
+
+		trackingInitStarted = true;
+		track( '', {
+			slug: 'neve',
+			license_id: tiobDash.license,
+			site: tiobDash.onboarding.homeUrl || '',
+		} )
+			.then( ( id ) => {
+				if ( id ) {
+					setTrackingId( id );
+				}
+			} )
+			.catch( () => {
+				trackingInitStarted = false;
+			} );
+
+		return () => clearTimeout( timeoutId );
+	}, [ showToast, trackingId, setShowToast, setTrackingId ] );
 
 	useEffect( () => {
-		handleShowToast();
-		setFetching( true );
-	}, [] );
+		if ( ! editor || ! onboarding?.root ) {
+			return undefined;
+		}
+
+		let active = true;
+		let safety;
+		const reveal = setTimeout( () => {
+			if ( active ) {
+				setPersonalizing( true );
+			}
+		}, 300 );
+		const done = () => {
+			if ( active ) {
+				clearTimeout( reveal );
+				clearTimeout( safety );
+				setPersonalizing( false );
+			}
+		};
+
+		safety = setTimeout( done, 9000 );
+		get(
+			onboarding.root +
+				'/starter_order?builder=' +
+				encodeURIComponent( editor )
+		)
+			.then( ( res ) => {
+				if ( active && res && Array.isArray( res.order ) && res.order.length ) {
+					setRankedOrder( editor, res.order );
+				}
+				done();
+			} )
+			.catch( done );
+
+		return () => {
+			active = false;
+			clearTimeout( reveal );
+			clearTimeout( safety );
+			setPersonalizing( false );
+		};
+	}, [ editor, setRankedOrder ] );
+
+	useEffect( () => {
+		if ( ! editor || ! onboarding?.root ) {
+			return undefined;
+		}
+
+		setSearchOrder( [] );
+		setSearchFailed( false );
+
+		const q = ( searchQuery || '' ).trim();
+		if ( q.length < 3 ) {
+			setSearching( false );
+			return undefined;
+		}
+
+		let active = true;
+		let safety;
+		const done = () => {
+			if ( active ) {
+				clearTimeout( safety );
+				setSearching( false );
+			}
+		};
+		const fail = () => {
+			if ( active ) {
+				setSearchFailed( true );
+			}
+			done();
+		};
+
+		const timer = setTimeout( () => {
+			if ( ! active ) {
+				return;
+			}
+
+			setSearching( true );
+			safety = setTimeout( fail, 9000 );
+			get(
+				onboarding.root +
+					'/starter_search?builder=' +
+					encodeURIComponent( editor ) +
+					'&q=' +
+					encodeURIComponent( q )
+			)
+				.then( ( res ) => {
+					if ( ! active ) {
+						return;
+					}
+
+					if ( res && Array.isArray( res.order ) && res.order.length ) {
+						setSearchOrder( res.order );
+						done();
+						return;
+					}
+
+					fail();
+				} )
+				.catch( fail );
+		}, 600 );
+
+		return () => {
+			active = false;
+			clearTimeout( timer );
+			clearTimeout( safety );
+		};
+	}, [ searchQuery, editor, setSearchFailed, setSearchOrder ] );
 
 	return (
 		<div className="ob-container">
@@ -50,28 +197,68 @@ const SiteList = ( { showToast, setShowToast, setFetching } ) => {
 				<div className="ob-title-wrap">
 					<h1>
 						{ __( 'Choose a design', 'templates-patterns-collection' ) }
-				</h1>
-				<EditorSelector />
-			</div>
-			<Filters />
-			<OnboardingPromoNotice />
-			<Sites />
-			{ ! tiobDash.isValidLicense && (
-				<Toast
-					setShowToast={ setShowToast }
-					svgIcon={ SVG.logo }
-					className={ showToast === true ? 'show' : '' }
-					message={ toastMessage }
-				/>
-			) }
+					</h1>
+					<EditorSelector />
+				</div>
+				<Filters />
+				<OnboardingPromoNotice />
+				{ ( personalizing || searching ) && (
+					<div
+						className="ob-ranking-loader"
+						role="status"
+						aria-live="polite"
+					>
+						<span className="ob-ranking-loader__dots">
+							<span />
+							<span />
+							<span />
+						</span>
+						<span className="ob-ranking-loader__text">
+							{ searching || ( searchQuery || '' ).trim().length >= 3
+								? __(
+										'Showing your matches — personalizing the rest in real time…',
+										'templates-patterns-collection'
+								  )
+								: __(
+										'Personalizing your starter sites…',
+										'templates-patterns-collection'
+								  ) }
+						</span>
+					</div>
+				) }
+				<Sites />
+				{ ! tiobDash.isValidLicense && (
+					<Toast
+						setShowToast={ setShowToast }
+						svgIcon={ SVG.logo }
+						className={ showToast === true ? 'show' : '' }
+						message={ toastMessage }
+					/>
+				) }
 			</div>
 		</div>
 	);
 };
 
-export default withDispatch( ( dispatch ) => {
-	const { setFetching } = dispatch( 'ti-onboarding' );
-	return {
-		setFetching,
-	};
-} )( SiteList );
+export default compose(
+	withSelect( ( select ) => ( {
+		editor: select( 'ti-onboarding' ).getCurrentEditor(),
+		searchQuery: select( 'ti-onboarding' ).getSearchQuery(),
+		trackingId: select( 'ti-onboarding' ).getTrackingId(),
+	} ) ),
+	withDispatch( ( dispatch ) => {
+		const {
+			setTrackingId,
+			setRankedOrder,
+			setSearchOrder,
+			setSearchFailed,
+		} = dispatch( 'ti-onboarding' );
+
+		return {
+			setTrackingId,
+			setRankedOrder,
+			setSearchOrder,
+			setSearchFailed,
+		};
+	} )
+)( SiteList );

--- a/onboarding/src/scss/_category-buttons.scss
+++ b/onboarding/src/scss/_category-buttons.scss
@@ -1,23 +1,22 @@
 .ob-cat-wrap {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 10px;
   .cat{
     color: $main-text;
     background: $light-bg;
     border: none;
     border-radius: 999px;
-    padding: 8px 24px;
-    font-size: 20px;
-    font-weight: 700;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 600;
     cursor: pointer;
     transition: 0.3s;
-    line-height: 30px;
+    line-height: 20px;
     &.active, &:hover {
       background: $dark-bg;
       color: $inverted-text;
     }
   }
 }
-
 

--- a/onboarding/src/scss/_filters.scss
+++ b/onboarding/src/scss/_filters.scss
@@ -1,7 +1,260 @@
-.ob-filters-container {
+.ob-filters {
+  margin: 36px 0 44px 0;
+}
+
+.ob-search-row {
+  margin-bottom: 26px;
+
+  .ob-search-wrap {
+    max-width: 560px;
+
+    input.search-input {
+      width: 100%;
+      max-width: 560px;
+      font-size: 16px;
+      padding: 15px 18px 15px 50px;
+    }
+
+    .search-icon {
+      top: 16px;
+    }
+  }
+}
+
+.ob-filters-bar {
   display: flex;
-  gap: 26px;
-  align-items: flex-start;
-  margin: 43px 0 48px 0;
+  align-items: center;
   flex-wrap: wrap;
+  gap: 16px;
+}
+
+.ob-search-hint {
+  margin: 10px 0 0 4px;
+  font-size: 13px;
+  color: #757575;
+}
+
+.ob-sort-select {
+  margin-left: auto;
+  min-width: 150px;
+
+  .components-input-control__backdrop {
+    border-color: transparent !important;
+    box-shadow: none !important;
+  }
+
+  .components-input-control__container {
+    background: $light-bg;
+    border-radius: 999px;
+  }
+
+  .components-base-control__field {
+    margin-bottom: 0 !important;
+  }
+
+  .components-select-control__input,
+  .components-input-control__input,
+  select {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    font-size: 14px;
+    font-weight: 600;
+    color: $main-text;
+    padding-left: 16px;
+  }
+}
+
+.ob-color-filter {
+  position: relative;
+}
+
+.ob-color-filter.is-open,
+.ob-color-filter:focus-within {
+  .ob-color-filter__panel {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .ob-color-filter__chevron {
+    transform: rotate(180deg);
+  }
+}
+
+.ob-color-filter__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  padding: 6px 12px;
+  border: 0;
+  border-radius: 999px;
+  background: $light-bg;
+  color: $main-text;
+  cursor: pointer;
+  transition: box-shadow 0.18s ease, background 0.18s ease;
+
+  &.has-selection {
+    box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.12);
+  }
+
+  &:hover {
+    background: #f2f2f2;
+  }
+}
+
+.ob-color-filter__swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  display: inline-block;
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.08);
+}
+
+.ob-color-filter__wheel {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  display: inline-block;
+  background: conic-gradient(
+    #ff5f6d 0deg,
+    #ffc371 70deg,
+    #7ed56f 140deg,
+    #4facfe 220deg,
+    #b06ab3 300deg,
+    #ff5f6d 360deg
+  );
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.75);
+}
+
+.ob-color-filter__label {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.ob-color-filter__chevron {
+  color: #6b7280;
+  font-size: 12px;
+  line-height: 1;
+  transition: transform 0.18s ease;
+}
+
+.ob-color-filter__panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 5;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  min-width: 260px;
+  padding: 10px;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.14);
+  opacity: 0;
+  transform: translateY(4px);
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.ob-color-filter__option,
+.ob-color-filter__clear {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: $main-text;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ob-color-filter__clear {
+  grid-column: 1 / -1;
+}
+
+.ob-color-filter__option:hover,
+.ob-color-filter__option.is-active,
+.ob-color-filter__clear:hover {
+  background: rgba(17, 24, 39, 0.05);
+}
+
+.ob-color-filter__name {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.ob-color-filter__clear {
+  justify-content: center;
+  color: #6b7280;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.ob-ranking-loader {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 22px 0;
+  padding: 9px 16px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #1e1e1e;
+  background: linear-gradient(90deg, #f3f0ff 0%, #eaf2ff 50%, #f3f0ff 100%);
+  background-size: 200% 100%;
+  animation: ob-loader-sheen 1.8s ease-in-out infinite;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+
+  &__dots {
+    display: inline-flex;
+    gap: 4px;
+
+    span {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #6c5ce7;
+      animation: ob-loader-bounce 1s ease-in-out infinite;
+    }
+
+    span:nth-child(2) {
+      animation-delay: 0.15s;
+    }
+
+    span:nth-child(3) {
+      animation-delay: 0.3s;
+    }
+  }
+}
+
+@keyframes ob-loader-bounce {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.55;
+  }
+
+  40% {
+    transform: translateY(-2px);
+    opacity: 1;
+  }
+}
+
+@keyframes ob-loader-sheen {
+  0% {
+    background-position: 0% 50%;
+  }
+
+  100% {
+    background-position: 200% 50%;
+  }
 }

--- a/onboarding/src/scss/_general.scss
+++ b/onboarding/src/scss/_general.scss
@@ -112,6 +112,25 @@ iframe {
   grid-template-columns: 1fr;
 }
 
+.ob-results-divider {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin: 8px 0;
+  color: #757575;
+  font-size: 14px;
+  font-weight: 600;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #e0e0e0;
+  }
+}
+
 .ob-title-wrap {
   display: flex;
   align-items: center;

--- a/onboarding/src/scss/_starter-site-card.scss
+++ b/onboarding/src/scss/_starter-site-card.scss
@@ -6,6 +6,7 @@
   margin-bottom: 14px;
   position: relative;
   border: 2px solid transparent;
+  background: #fff;
 
   &:hover {
     border: 2px solid #3498db;
@@ -31,14 +32,185 @@
     background-repeat: no-repeat;
     background-position: top center;
     background-color: transparentize($dark-bg, .75);
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 12px;
+  }
+
+  &:hover,
+  &:focus-within {
+    .ss-page-shots {
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
+    }
   }
 }
 
 .ss-title {
   color: $main-text;
-  text-align: center;
   margin: 0;
   font-size: 16px;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.ss-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 8px 8px;
+}
+
+.ss-description {
+  color: transparentize($main-text, 0.18);
+  margin: 0;
+  font-size: 13px;
+  line-height: 20px;
+  display: -webkit-box;
+  overflow: hidden;
+  text-align: left;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.ss-page-shots {
+  display: inline-flex;
+  gap: 6px;
+  padding: 5px;
+  max-width: 100%;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 8px 24px rgba(12, 19, 31, 0.12);
+  overflow-x: auto;
+  opacity: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.ss-page-shot {
+  border: 0;
+  background: transparent;
+  color: #4f5b66;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 8px 10px;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &.is-active {
+    background: #111;
+    color: #fff;
+  }
+}
+
+.ss-color-summary {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 4px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 6px 18px rgba(12, 19, 31, 0.12);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+  z-index: 2;
+  gap: 6px;
+
+  &:hover {
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.99);
+    box-shadow: 0 10px 22px rgba(12, 19, 31, 0.16);
+  }
+}
+
+.ss-color-summary__collapsed {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ss-color-summary__expanded {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-start;
+}
+
+.ss-color-summary__swatches {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+}
+
+.ss-color-summary__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.08);
+  color: #4b5563;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.ss-color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  display: inline-block;
+  background: #94a3b8;
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.06);
+  transition: transform 0.18s ease;
+
+  & + .ss-color-dot {
+    margin-left: 2px;
+  }
+}
+
+.ss-color-swatch {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  background: transparent;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  flex: 0 0 auto;
+
+  &:hover {
+    transform: translateY(-1px);
+  }
+
+  &.is-active {
+    border-color: #111;
+    box-shadow: 0 0 0 1.5px rgba(17, 24, 39, 0.12);
+  }
+
+  .ss-color-dot {
+    margin-left: 0;
+  }
+}
+
+.ss-color-summary.is-expanded {
+  background: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 14px 30px rgba(12, 19, 31, 0.18);
 }

--- a/onboarding/src/store/actions.js
+++ b/onboarding/src/store/actions.js
@@ -71,4 +71,34 @@ export default {
 			payload: { refresh },
 		};
 	},
+	setSortBy( sortBy ) {
+		return {
+			type: 'SET_SORT_BY',
+			payload: { sortBy },
+		};
+	},
+	setRankedOrder( editor, order ) {
+		return {
+			type: 'SET_RANKED_ORDER',
+			payload: { editor, order },
+		};
+	},
+	setSearchOrder( order ) {
+		return {
+			type: 'SET_SEARCH_ORDER',
+			payload: { order },
+		};
+	},
+	setSearchFailed( failed ) {
+		return {
+			type: 'SET_SEARCH_FAILED',
+			payload: { failed },
+		};
+	},
+	setSelectedColors( colors ) {
+		return {
+			type: 'SET_SELECTED_COLORS',
+			payload: { colors },
+		};
+	},
 };

--- a/onboarding/src/store/reducer.js
+++ b/onboarding/src/store/reducer.js
@@ -34,14 +34,12 @@ const defaultSite = defaultSiteSlug ? findSiteBySlug( defaultSiteSlug ) : null;
 const initialState = {
 	sites: onboarding.sites || {},
 	editor: selectedEditor,
-	category: '',
+	category: 'all',
 	currentSite: defaultSite,
 	fetching: false,
 	searchQuery: '',
 	license: initialLicense,
-	onboardingStep: defaultSite
-		? 3
-		: ( window.location.search.includes('show=welcome') ? 1 : 2 ),
+	onboardingStep: defaultSite ? 3 : 2,
 	userCustomSettings: {
 		siteName: null,
 		siteLogo: null,
@@ -51,6 +49,11 @@ const initialState = {
 	error: null,
 	trackingId: '',
 	refresh: false,
+	sortBy: 'recommended',
+	rankedOrder: {},
+	searchOrder: [],
+	searchFailed: false,
+	selectedColors: [],
 };
 
 export default ( state = initialState, action ) => {
@@ -72,6 +75,8 @@ export default ( state = initialState, action ) => {
 			return {
 				...state,
 				searchQuery: query,
+				searchOrder: [],
+				searchFailed: false,
 			};
 		case 'SET_FOCUSED_SITE':
 			const { siteData } = action.payload;
@@ -115,6 +120,10 @@ export default ( state = initialState, action ) => {
 			return {
 				...state,
 				editor,
+				sortBy:
+					state.sortBy === 'new' && editor !== 'gutenberg'
+						? 'recommended'
+						: state.sortBy,
 			};
 		case 'SET_TRACKING_ID':
 			const { trackingId } = action.payload;
@@ -127,6 +136,39 @@ export default ( state = initialState, action ) => {
 			return {
 				...state,
 				refresh,
+			};
+		case 'SET_SORT_BY':
+			const { sortBy } = action.payload;
+			return {
+				...state,
+				sortBy,
+			};
+		case 'SET_RANKED_ORDER':
+			const { editor: rankedEditor, order: rankedOrder } = action.payload;
+			return {
+				...state,
+				rankedOrder: {
+					...state.rankedOrder,
+					[ rankedEditor ]: rankedOrder,
+				},
+			};
+		case 'SET_SEARCH_ORDER':
+			const { order: searchOrder } = action.payload;
+			return {
+				...state,
+				searchOrder,
+			};
+		case 'SET_SEARCH_FAILED':
+			const { failed } = action.payload;
+			return {
+				...state,
+				searchFailed: failed,
+			};
+		case 'SET_SELECTED_COLORS':
+			const { colors } = action.payload;
+			return {
+				...state,
+				selectedColors: Array.isArray( colors ) ? colors : [],
 			};
 	}
 	return state;

--- a/onboarding/src/store/selectors.js
+++ b/onboarding/src/store/selectors.js
@@ -24,4 +24,9 @@ export default {
 	getUserCustomSettings: ( state ) => state.userCustomSettings,
 	getTrackingId: ( state ) => state.trackingId,
 	getRefresh: ( state ) => state.refresh,
+	getSortBy: ( state ) => state.sortBy,
+	getRankedOrder: ( state ) => state.rankedOrder,
+	getSearchOrder: ( state ) => state.searchOrder,
+	getSearchFailed: ( state ) => state.searchFailed,
+	getSelectedColors: ( state ) => state.selectedColors,
 };

--- a/onboarding/src/utils/common.js
+++ b/onboarding/src/utils/common.js
@@ -5,6 +5,8 @@ const trailingSlashIt = ( str ) => untrailingSlashIt( str ) + '/';
 
 const ONBOARDING_CAT = {
 	business: __( 'Business', 'templates-patterns-collection' ),
+	blog: __( 'Blog', 'templates-patterns-collection' ),
+	portfolio: __( 'Portfolio', 'templates-patterns-collection' ),
 	education: __( 'Education', 'templates-patterns-collection' ),
 	woocommerce: __( 'eCommerce', 'templates-patterns-collection' ),
 	news: __( 'News', 'templates-patterns-collection' ),

--- a/onboarding/src/utils/search.js
+++ b/onboarding/src/utils/search.js
@@ -1,0 +1,40 @@
+import Fuse from 'fuse.js/dist/fuse.min';
+
+const SEARCH_KEYS = [
+	{ name: 'title', weight: 0.5 },
+	{ name: 'category', weight: 0.35 },
+	{ name: 'slug', weight: 0.3 },
+	{ name: 'site_description', weight: 0.25 },
+	{ name: 'description', weight: 0.25 },
+	{ name: 'keywords', weight: 0.2 },
+];
+
+const SEARCH_THRESHOLD = 0.3;
+
+export const searchCatalog = ( items, query ) => {
+	const q = ( query || '' ).trim();
+	if ( ! q || ! Array.isArray( items ) || ! items.length ) {
+		return [];
+	}
+
+	return new Fuse( items, {
+		includeScore: true,
+		threshold: SEARCH_THRESHOLD,
+		keys: SEARCH_KEYS,
+	} )
+		.search( q )
+		.map( ( result ) => result.item )
+		.filter( Boolean );
+};
+
+export const matchesCategory = ( site, cat ) => {
+	if ( 'free' === cat ) {
+		return ! site.upsell;
+	}
+
+	if ( cat && 'all' !== cat ) {
+		return Array.isArray( site.keywords ) && site.keywords.includes( cat );
+	}
+
+	return true;
+};


### PR DESCRIPTION
### Summary
- remove the welcome gate so onboarding lands directly on the starter grid with a stronger search-first layout
- add AI-backed starter ordering and semantic search endpoints, client-side state handling, loader states, divider treatment, and search fallback behavior
- add richer card descriptions plus color/page-shot UI support when the catalog provides that metadata
- add repo guidance in AGENTS.md and align onboarding categories, sort controls, and filter styling with the new flow

### Test instructions
- Run `yarn build:onboarding`
- Point the plugin at the companion agents workflow PR and open the onboarding wizard locally
- Verify recommended ordering, semantic search, color filtering, card color/page-shot UI, and telemetry across preview/import flows

Companion backend PR: Codeinwp/agents#49
Part of Codeinwp/neve-pro-addon#3172
