### PR TITLE
feat(onboarding): truly cancel superseded starter-site searches

### DIFF
--- a/onboarding/src/Components/Steps/SiteList.js
+++ b/onboarding/src/Components/Steps/SiteList.js
@@ -17,6 +17,11 @@ import { get, track } from '../../utils/rest';
 
 const { onboarding } = tiobDash;
 
+// Debounce the search so it stays off the network while typing: only fire after the
+// field is idle for SEARCH_DEBOUNCE_MS and the query is at least SEARCH_MIN_CHARS.
+const SEARCH_DEBOUNCE_MS = 700;
+const SEARCH_MIN_CHARS = 3;
+
 // Guards tracking-session init against firing twice while the first request is in flight.
 let trackingInitStarted = false;
 
@@ -89,7 +94,6 @@ const SiteList = ( {
 		}
 
 		let active = true;
-		let safety;
 		const reveal = setTimeout( () => {
 			if ( active ) {
 				setPersonalizing( true );
@@ -103,7 +107,7 @@ const SiteList = ( {
 			}
 		};
 
-		safety = setTimeout( done, 9000 );
+		const safety = setTimeout( done, 9000 );
 		get(
 			onboarding.root +
 				'/starter_order?builder=' +
@@ -134,13 +138,15 @@ const SiteList = ( {
 		setSearchFailed( false );
 
 		const q = ( searchQuery || '' ).trim();
-		if ( q.length < 3 ) {
+		if ( q.length < SEARCH_MIN_CHARS ) {
 			setSearching( false );
 			return undefined;
 		}
 
 		let active = true;
 		let safety;
+		// Lets cleanup abort a superseded in-flight request, not just ignore its result.
+		const controller = new AbortController();
 		const done = () => {
 			if ( active ) {
 				clearTimeout( safety );
@@ -166,7 +172,10 @@ const SiteList = ( {
 					'/starter_search?builder=' +
 					encodeURIComponent( editor ) +
 					'&q=' +
-					encodeURIComponent( q )
+					encodeURIComponent( q ),
+				false,
+				true,
+				controller.signal
 			)
 				.then( ( res ) => {
 					if ( ! active ) {
@@ -181,11 +190,18 @@ const SiteList = ( {
 
 					fail();
 				} )
-				.catch( fail );
-		}, 600 );
+				.catch( ( err ) => {
+					// Aborted = superseded, not a real failure → skip the fallback.
+					if ( err && err.name === 'AbortError' ) {
+						return;
+					}
+					fail();
+				} );
+		}, SEARCH_DEBOUNCE_MS );
 
 		return () => {
 			active = false;
+			controller.abort();
 			clearTimeout( timer );
 			clearTimeout( safety );
 		};

--- a/onboarding/src/utils/rest.js
+++ b/onboarding/src/utils/rest.js
@@ -5,8 +5,8 @@ export const send = ( route, data, simple = false ) => {
 	return requestData( route, simple, data );
 };
 
-export const get = ( route, simple = false, useNonce = true ) => {
-	return requestData( route, simple, {}, 'GET', useNonce );
+export const get = ( route, simple = false, useNonce = true, signal = null ) => {
+	return requestData( route, simple, {}, 'GET', useNonce, signal );
 };
 
 const requestData = async (
@@ -14,7 +14,8 @@ const requestData = async (
 	simple = false,
 	data = {},
 	method = 'POST',
-	useNonce = true
+	useNonce = true,
+	signal = null
 ) => {
 	const options = {
 		method,
@@ -35,6 +36,11 @@ const requestData = async (
 
 	if ( useNonce ) {
 		options.headers[ 'x-wp-nonce' ] = tiobDash.nonce;
+	}
+
+	// Optional AbortSignal so callers can cancel an in-flight request.
+	if ( signal ) {
+		options.signal = signal;
 	}
 
 	if ( 'POST' === method ) {


### PR DESCRIPTION
## What & why

The onboarding starter-site search (LLM-ranked) already debounced and ignored stale responses via an `active` flag — but a **superseded in-flight request still ran to completion on the backend**. Typing `med → medica → medical` could leave earlier requests churning on the AI proxy even though their results were thrown away.

This adds **true cancellation**: each debounced request gets its own `AbortController`, and the effect cleanup calls `abort()` — so a new keystroke (or editor switch) drops the prior LLM call instead of just discarding its result. Less wasted backend work, no late-result flicker.

## Changes

- **`onboarding/src/utils/rest.js`** — thread an optional `AbortSignal` through `get()` → `requestData()` → `fetch(options.signal)`. Inert when omitted (back-compat for all other callers).
- **`onboarding/src/Components/Steps/SiteList.js`**
  - Per-request `AbortController`; `controller.abort()` in the search effect's cleanup.
  - `.catch` swallows `AbortError` so an intentional cancel does **not** flip `searchFailed` (which would spuriously trigger the Fuse fallback). Genuine errors / 404 / hang / empty still fall back as before.
  - Extracted `SEARCH_DEBOUNCE_MS` / `SEARCH_MIN_CHARS` constants. **Debounce bumped 600ms → 700ms** so the search waits until typing has more confidently settled (still in the 500–800ms range). **Min chars stays 3** (preserves real short niches: spa, gym, law, art, vet…).
  - Tidied a pre-existing `let safety` → `const safety` in the personalization effect (clears the lint `prefer-const`).

## Base

Branched off `development` (identical to released `master` 1.3.0 for these files). The debounce/min-chars themselves already shipped in 1.3.0 — this PR is the missing **cancellation** piece plus the tuning.

## Verification

- ✅ `wp-scripts lint-js` — 0 errors, 0 warnings
- ✅ `wp-scripts build onboarding` — compiles
- ✅ Mechanism test (18 assertions): real `rest.js` `get()` signal threading + faithful reproduction of the search effect's control flow — debounce collapses rapid keystrokes to one request, 3-char gate, **true abort on supersede**, abort doesn't trip the fallback, success/empty/error paths, stale-response guard.
- ✅ Adversarial multi-agent review (3 lenses → verify): 6 candidate findings, **0 confirmed real** (AbortError classification reliable — native fetch, `whatwg-fetch` unused; no microtask race; no safety-timer leak; no TDZ on the `const` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
