### PR TITLE
feat(onboarding): show 4 starter sites per row on laptop and up

### DIFF
--- a/e2e-tests/specs/onboarding.spec.js
+++ b/e2e-tests/specs/onboarding.spec.js
@@ -48,9 +48,12 @@ test.describe('Onboarding', () => {
         expect(await page.locator('.ss-card .ss-badge').count()).toBeGreaterThan(0);
 
         // 'All' and 'Free' should show after you select a category.
+        // Match exactly: card page-shot buttons (e.g. "Gallery", "Ballet Blog",
+        // "All Courses") also contain "all" as a substring, so a non-exact name
+        // match resolves to multiple elements once the grid renders a full page.
         await page.locator('.ob-cat-wrap').first().click();
-        await expect(page.getByRole('button', { name: 'All' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Free' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'All', exact: true })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Free', exact: true })).toBeVisible();
 
         // Check card structure.
         const firstListedSiteCard = page.locator('.ss-card-wrap').first();

--- a/onboarding/src/Components/Sites.js
+++ b/onboarding/src/Components/Sites.js
@@ -27,11 +27,11 @@ const Sites = ( {
 	sortBy,
 	selectedColors,
 } ) => {
-	const [ maxShown, setMaxShown ] = useState( 9 );
+	const [ maxShown, setMaxShown ] = useState( 12 );
 	const { sites = {} } = getSites;
 
 	useEffect( () => {
-		setMaxShown( 9 );
+		setMaxShown( 12 );
 	}, [ editor, category, searchQuery, sortBy, selectedColors ] );
 
 	const getBuilders = () => Object.keys( sites );
@@ -218,9 +218,9 @@ const Sites = ( {
 			const rest = filterByColors( filterByCategory( ranked, category ) ).filter(
 				( site ) => site && site.slug && ! inMatches[ site.slug ]
 			);
-			const remainder = matches.length % 3;
+			const remainder = matches.length % 4;
 			const pad =
-				remainder === 0 ? 0 : Math.min( 3 - remainder, rest.length );
+				remainder === 0 ? 0 : Math.min( 4 - remainder, rest.length );
 
 			return {
 				list: [ ...matches, ...rest ],
@@ -280,7 +280,7 @@ const Sites = ( {
 								return false;
 							}
 
-							setMaxShown( ( shown ) => shown + 9 );
+							setMaxShown( ( shown ) => shown + 12 );
 						} }
 					>
 						<span

--- a/onboarding/src/scss/_general.scss
+++ b/onboarding/src/scss/_general.scss
@@ -231,7 +231,7 @@ input.components-text-control__input[type="email"],
 
 @mixin ob-general--laptop() {
   .ob-sites.is-grid {
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary

Widen the onboarding starter-sites grid from **3 to 4 columns on laptop and up** so users see ~8 templates at once instead of leaving large empty margins on wider screens. Cards get narrower but stay tall enough to read clearly (aspect-ratio `0.84/1`).

Closes #477

## What changed

- **`onboarding/src/scss/_general.scss`** — `ob-general--laptop()` now sets `grid-template-columns: repeat(4, minmax(0, 1fr))` (was `1fr 1fr 1fr`). `minmax(0, 1fr)` prevents grid blowout from long titles. This cascades to the desktop/desktop-large breakpoints (which were empty). Tablet stays at 2 columns, mobile at 1.
- **`onboarding/src/Components/Sites.js`**
  - Page size `9 → 12` in the initial `useState`, the reset effect, and the lazy-load increment — so every render and each scroll-load fills whole rows. **12 divides evenly by both 3 and 4**, so rows stay full at every breakpoint.
  - Search row padding `% 3 → % 4` (and `3 - remainder → 4 - remainder`) so the "Not quite right? Browse more" divider lands on a clean row boundary under the 4-column grid.

## How to test

1. `yarn build` (compiles the onboarding bundle — `build/` is gitignored, so only `src/` is committed here).
2. Open the Neve onboarding starter-sites step on a screen ≥992px.
3. Verify **4 sites per row** (2 on tablet ≥660px, 1 on mobile).
4. Scroll to confirm lazy-load appends full rows of 4.
5. Run a search and confirm the "Browse more" divider sits on a clean row boundary with no orphaned trailing card.

## Notes

- Source-only change; the compiled bundle is produced by the build step.
- A reviewer alternative was to gate 4 columns at the desktop breakpoint (≥1200px) and keep laptops at 3, for slightly larger cards in the 992–1199px band. This PR instead applies 4 columns from 992px up per the requested behavior ("4 per row on laptop"). Easy to switch if preferred.


## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR
