### PR TITLE
fix(onboarding): color picker — hide for single palette + sync screenshot to filter

### DIFF
--- a/onboarding/src/Components/StarterSiteCard.js
+++ b/onboarding/src/Components/StarterSiteCard.js
@@ -47,7 +47,8 @@ const StarterSiteCard = ( {
 	setSite,
 	handleNextStep,
 	trackingId,
-	editor
+	editor,
+	selectedColors = []
 } ) => {
 	const {
 		upsell,
@@ -93,6 +94,32 @@ const StarterSiteCard = ( {
 			screenshot: screenshotMap[ color ] || screenshot,
 		} ) );
 	}, [ data?.colors, data?.screenshots_by_color, screenshot ] );
+	// First globally-selected color this card actually has, returned as the
+	// canonical RAW colorOptions slug so option.slug === activeColor still hits.
+	// selectedColors are normalized lowercase (Filters.js) while colorOptions
+	// slugs / screenshots_by_color keys are raw, so match case-insensitively.
+	const filterColor = useMemo( () => {
+		if (
+			! Array.isArray( selectedColors ) ||
+			! selectedColors.length ||
+			! colorOptions.length
+		) {
+			return '';
+		}
+
+		const normalizedToSlug = new Map(
+			colorOptions.map( ( option ) => [
+				String( option.slug || '' ).trim().toLowerCase(),
+				option.slug,
+			] )
+		);
+
+		const matched = selectedColors.find( ( color ) =>
+			normalizedToSlug.has( color )
+		);
+
+		return matched ? normalizedToSlug.get( matched ) : '';
+	}, [ selectedColors, colorOptions ] );
 	const previewColors = colorOptions.slice( 0, 2 );
 	const [ activePage, setActivePage ] = useState( pageShots[0]?.key || 'home' );
 	const [ activeColor, setActiveColor ] = useState( colorOptions[0]?.slug || '' );
@@ -102,9 +129,12 @@ const StarterSiteCard = ( {
 		setActivePage( pageShots[0]?.key || 'home' );
 	}, [ pageShots ] );
 
+	// Seed the displayed color from the global filter when this card matches a
+	// selected color; otherwise fall back to the first palette. Re-runs only on
+	// filter/colorOptions changes, so manual swatch clicks survive until then.
 	useEffect( () => {
-		setActiveColor( colorOptions[0]?.slug || '' );
-	}, [ colorOptions ] );
+		setActiveColor( filterColor || colorOptions[0]?.slug || '' );
+	}, [ colorOptions, filterColor ] );
 
 	const activePageShot =
 		pageShots.find( ( shot ) => shot.key === activePage ) || pageShots[0] || null;
@@ -290,12 +320,14 @@ export default compose(
 			getCurrentEditor,
 			getCurrentCategory,
 			getSearchQuery,
+			getSelectedColors,
 		} = select( 'ti-onboarding' );
 		return {
 			trackingId: getTrackingId(),
 			editor: getCurrentEditor(),
 			category: getCurrentCategory(),
 			query: getSearchQuery(),
+			selectedColors: getSelectedColors() || [],
 		};
 	} ),
 	withDispatch( ( dispatch, { data } ) => {

--- a/onboarding/src/Components/StarterSiteCard.js
+++ b/onboarding/src/Components/StarterSiteCard.js
@@ -194,7 +194,7 @@ const StarterSiteCard = ( {
 								) ) }
 							</div>
 						) }
-						{ colorOptions.length > 0 && (
+						{ colorOptions.length > 1 && (
 							<div
 								className={
 									isColorExpanded


### PR DESCRIPTION
Two related fixes to the onboarding starter-site **color picker** (`StarterSiteCard.js`).

### 1. Hide the picker when a site has a single palette
The swatch summary rendered whenever a site had ≥1 color, showing a lone non-actionable dot. Now gated on `colorOptions.length > 1`.

### 2. Sync the card screenshot to the selected color filter
Selecting a color in the global filter already narrowed the grid to matching sites, but each card still showed its **default** palette screenshot. Now a matching card switches its screenshot to the selected color's palette (`screenshots_by_color`):
- subscribe to `getSelectedColors` via `withSelect`;
- derive `filterColor` = the first selected color the card actually has (case-insensitive; returns the raw `colorOptions` slug so `option.slug === activeColor` still matches);
- seed `activeColor` from `filterColor` (fallback to the first palette) in an effect keyed on `[colorOptions, filterColor]` — so **manual swatch clicks survive** until the filter changes, and **clearing the filter reverts** to the default;
- graceful fallback to the base screenshot when `screenshots_by_color` lacks the selected color.

No store / `Sites.js` / `Filters.js` changes — the store already exposes `getSelectedColors`.

### Tested
Verified in a local `wp-env` Neve onboarding instance against the live catalog (which now carries color data): selecting **green** filtered the grid and switched matching cards to their `-green` screenshots (`cb:marketing-agency-gb-green`, `cb:web-agency-gb-green`, …); single-palette sites show no swatch; clearing reverts.
