### PR TITLE
fix(onboarding): reveal color swatch only on hover

### DIFF
--- a/onboarding/src/scss/_starter-site-card.scss
+++ b/onboarding/src/scss/_starter-site-card.scss
@@ -46,6 +46,12 @@
       transform: translateY(0);
       pointer-events: auto;
     }
+
+    .ss-color-summary {
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
+    }
   }
 }
 
@@ -122,12 +128,17 @@
   background: rgba(255, 255, 255, 0.96);
   backdrop-filter: blur(8px);
   box-shadow: 0 6px 18px rgba(12, 19, 31, 0.12);
-  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+  // Hidden at rest — revealed only when the card is hovered/focused (like the page-shots),
+  // so it adds no visual noise to the resting grid.
+  opacity: 0;
+  transform: translateY(4px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.18s ease,
+    background 0.18s ease;
   z-index: 2;
   gap: 6px;
 
   &:hover {
-    transform: translateY(-1px);
     background: rgba(255, 255, 255, 0.99);
     box-shadow: 0 10px 22px rgba(12, 19, 31, 0.16);
   }


### PR DESCRIPTION
## Summary

The per-card color swatch summary showed at rest, adding visual noise to the starter-sites grid. This hides it at rest and reveals it only on **card hover / focus** — matching the existing page-shot tabs — so the resting grid stays clean.

- `.ss-color-summary` is now `opacity: 0; pointer-events: none` at rest, revealed via the existing `.ss-card:hover, :focus-within` block (with a small slide-up). The full white pill + shadow still appear on hover; keyboard focus reveals it via `:focus-within`.

Targets `development` so it ships in the v1.4.0 starter-sites release (#481).

## Test

Open Neve onboarding (≥992px): at rest the cards show no color swatch; hovering (or tabbing into) a multi-palette card reveals the swatch at the bottom-left (and the page-shot tabs at top). Single-palette sites still show nothing.

Verified in a local wp-env instance — resting opacity 0, hover opacity 1.
