### PR TITLE
Development

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38e7ceb1d2ce66aa860aea884d3fd3ae",
+    "content-hash": "2edb140d9732e088a052918719096234",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.53",
+            "version": "3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "a657eaedf62cc84c82e539167ac9e19b3e618ce8"
+                "reference": "095c2d0f1388af0b0196c492a7f79e2fd092dab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/a657eaedf62cc84c82e539167ac9e19b3e618ce8",
-                "reference": "a657eaedf62cc84c82e539167ac9e19b3e618ce8",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/095c2d0f1388af0b0196c492a7f79e2fd092dab1",
+                "reference": "095c2d0f1388af0b0196c492a7f79e2fd092dab1",
                 "shasum": ""
             },
             "require-dev": {
@@ -43,9 +43,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.53"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.54"
             },
-            "time": "2026-06-18T07:32:53+00:00"
+            "time": "2026-06-23T13:43:47+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/Sites_Listing.php
+++ b/includes/Sites_Listing.php
@@ -20,9 +20,19 @@ class Sites_Listing {
 	/**
 	 * Key of transient where we save the sites list.
 	 *
+	 * The key is version-stamped so that a plugin update always busts a
+	 * potentially stuck cache.
+	 *
 	 * @var string
 	 */
-	private $transient_key = 'tiob_sites';
+	private $transient_key = 'tiob_sites_' . TIOB_VERSION;
+
+	/**
+	 * How long the sites list cache is considered fresh, in seconds.
+	 *
+	 * @var int
+	 */
+	private $cache_ttl = 12 * HOUR_IN_SECONDS;
 
 	/**
 	 * The onboarding config.
@@ -108,11 +118,9 @@ class Sites_Listing {
 	 * @return array
 	 */
 	private function get_sites() {
-		$cache = get_transient( $this->transient_key );
+		$response = $this->get_cached_sites();
 
-		if ( $cache !== false ) {
-			$response = $cache;
-		} else {
+		if ( $response === false ) {
 			$response = wp_remote_get( esc_url( self::get_api_path() ) );
 
 			if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
@@ -160,9 +168,41 @@ class Sites_Listing {
 			}
 		}
 
-		set_transient( $this->transient_key, $response, 12 * HOUR_IN_SECONDS );
+		set_transient(
+			$this->transient_key,
+			array(
+				'fetched_at' => time(),
+				'data'       => $response,
+			),
+			$this->cache_ttl
+		);
 
 		return $response;
+	}
+
+	/**
+	 * Get the cached sites list, if it is still fresh.
+	 *
+	 * Instead of relying solely on the transient timeout row - which external
+	 * DB/transient cleanup tools can strip, leaving the value non-expiring and
+	 * served forever - we embed our own `fetched_at` timestamp in the payload
+	 * and validate it on read.
+	 *
+	 * @return array|false The cached sites data, or false when there is no
+	 *                     fresh cache and a fresh fetch is required.
+	 */
+	private function get_cached_sites() {
+		$cache = get_transient( $this->transient_key );
+
+		if ( ! is_array( $cache ) || ! isset( $cache['fetched_at'], $cache['data'] ) ) {
+			return false;
+		}
+
+		if ( ( time() - (int) $cache['fetched_at'] ) >= $this->cache_ttl ) {
+			return false;
+		}
+
+		return $cache['data'];
 	}
 
 	/**

--- a/onboarding/src/Components/FeaturesList.js
+++ b/onboarding/src/Components/FeaturesList.js
@@ -1,13 +1,8 @@
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { decodeHtmlEntities } from '../utils/common';
 
 const MAX_FEATURE_LIST_LENGTH = 6;
-
-const decodeHtmlEntities = (str) => {
-    const textArea = document.createElement('textarea');
-    textArea.innerHTML = str;
-    return textArea.value;
-};
 
 /**
  * Plugins to promote.

--- a/onboarding/src/Components/StarterSiteCard.js
+++ b/onboarding/src/Components/StarterSiteCard.js
@@ -5,6 +5,12 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { track } from '../utils/rest';
 
+const decodeHtmlEntities = ( str ) => {
+	const txt = document.createElement( 'textarea' );
+	txt.innerHTML = str;
+	return txt.value;
+};
+
 const hashColor = ( value = '' ) => {
 	let hash = 0;
 	for ( let index = 0; index < value.length; index++ ) {
@@ -77,7 +83,7 @@ const StarterSiteCard = ( {
 			.filter( ( shot ) => shot && shot.screenshot )
 			.map( ( shot ) => ( {
 				key: shot.key || shot.label || 'page',
-				label: shot.label || shot.key || __( 'Page', 'templates-patterns-collection' ),
+				label: decodeHtmlEntities( shot.label || shot.key || __( 'Page', 'templates-patterns-collection' ) ),
 				screenshot: shot.screenshot,
 			} ) );
 	}, [ data?.page_shots, screenshot ] );

--- a/onboarding/src/Components/StarterSiteCard.js
+++ b/onboarding/src/Components/StarterSiteCard.js
@@ -4,12 +4,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { track } from '../utils/rest';
-
-const decodeHtmlEntities = ( str ) => {
-	const txt = document.createElement( 'textarea' );
-	txt.innerHTML = str;
-	return txt.value;
-};
+import { decodeHtmlEntities } from '../utils/common';
 
 const hashColor = ( value = '' ) => {
 	let hash = 0;

--- a/onboarding/src/utils/common.js
+++ b/onboarding/src/utils/common.js
@@ -51,6 +51,12 @@ const textToFileURL = ( text ) => {
 	return URL.createObjectURL( blob );
 };
 
+const decodeHtmlEntities = ( str ) => {
+	const txt = document.createElement( 'textarea' );
+	txt.innerHTML = str;
+	return txt.value;
+};
+
 export {
 	trailingSlashIt,
 	untrailingSlashIt,
@@ -58,4 +64,5 @@ export {
 	EDITOR_MAP,
 	ONBOARDING_CAT,
 	textToFileURL,
+	decodeHtmlEntities,
 };

--- a/tests/sites-listing-test.php
+++ b/tests/sites-listing-test.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Test Sites_Listing caching.
+ *
+ * @package templates-patterns-collection
+ */
+
+use TIOB\Sites_Listing;
+
+/**
+ * Test the Starter Sites listing cache behavior.
+ */
+class Sites_Listing_Test extends \WP_UnitTestCase {
+
+	/**
+	 * @var Sites_Listing
+	 */
+	private $sites_listing;
+
+	/**
+	 * How many times the remote API was hit during a test.
+	 *
+	 * @var int
+	 */
+	private $remote_calls = 0;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->sites_listing = new Sites_Listing();
+		$this->remote_calls  = 0;
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		delete_transient( $this->get_transient_key() );
+		parent::tear_down();
+	}
+
+	/**
+	 * Mock the remote sites API with a payload of the given editors.
+	 *
+	 * @param array $payload Response payload.
+	 */
+	private function mock_api( $payload ) {
+		add_filter(
+			'pre_http_request',
+			function () use ( $payload ) {
+				$this->remote_calls++;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode( $payload ),
+				);
+			}
+		);
+	}
+
+	/**
+	 * Read the private transient key from the instance.
+	 *
+	 * @return string
+	 */
+	private function get_transient_key() {
+		$property = new ReflectionProperty( Sites_Listing::class, 'transient_key' );
+		$property->setAccessible( true );
+
+		return $property->getValue( $this->sites_listing );
+	}
+
+	/**
+	 * Invoke the private get_sites method.
+	 *
+	 * @return array
+	 */
+	private function get_sites() {
+		$method = new ReflectionMethod( $this->sites_listing, 'get_sites' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->sites_listing );
+	}
+
+	/**
+	 * The version-stamped transient key should include the plugin version.
+	 */
+	public function test_transient_key_is_version_stamped() {
+		$this->assertSame( 'tiob_sites_' . TIOB_VERSION, $this->get_transient_key() );
+	}
+
+	/**
+	 * A fresh fetch should store the payload wrapped with a fetched_at stamp.
+	 */
+	public function test_fetch_stores_wrapped_payload() {
+		$this->mock_api( array( 'gutenberg' => array( 'site-a' => array() ) ) );
+
+		$sites = $this->get_sites();
+
+		$this->assertArrayHasKey( 'gutenberg', $sites );
+		$this->assertSame( 1, $this->remote_calls );
+
+		$cache = get_transient( $this->get_transient_key() );
+		$this->assertIsArray( $cache );
+		$this->assertArrayHasKey( 'fetched_at', $cache );
+		$this->assertArrayHasKey( 'data', $cache );
+		$this->assertArrayHasKey( 'gutenberg', $cache['data'] );
+	}
+
+	/**
+	 * A fresh cache should be served without hitting the remote API.
+	 */
+	public function test_fresh_cache_is_served_without_remote_call() {
+		set_transient(
+			$this->get_transient_key(),
+			array(
+				'fetched_at' => time(),
+				'data'       => array( 'gutenberg' => array( 'cached-site' => array() ) ),
+			),
+			12 * HOUR_IN_SECONDS
+		);
+
+		$this->mock_api( array( 'gutenberg' => array( 'fresh-site' => array() ) ) );
+
+		$sites = $this->get_sites();
+
+		$this->assertArrayHasKey( 'cached-site', $sites['gutenberg'] );
+		$this->assertSame( 0, $this->remote_calls );
+	}
+
+	/**
+	 * An orphaned-timeout transient (value present but our own fetched_at is
+	 * past the TTL) must trigger a re-fetch instead of being served forever.
+	 */
+	public function test_stale_fetched_at_triggers_refetch() {
+		set_transient(
+			$this->get_transient_key(),
+			array(
+				'fetched_at' => time() - ( 13 * HOUR_IN_SECONDS ),
+				'data'       => array( 'gutenberg' => array( 'old-site' => array() ) ),
+			),
+			12 * HOUR_IN_SECONDS
+		);
+
+		$this->mock_api( array( 'gutenberg' => array( 'new-site' => array() ) ) );
+
+		$sites = $this->get_sites();
+
+		$this->assertArrayHasKey( 'new-site', $sites['gutenberg'] );
+		$this->assertArrayNotHasKey( 'old-site', $sites['gutenberg'] );
+		$this->assertSame( 1, $this->remote_calls );
+	}
+
+	/**
+	 * A legacy cache payload (raw sites array, no fetched_at wrapper) must not
+	 * be served indefinitely; it should be treated as stale and re-fetched.
+	 */
+	public function test_legacy_cache_payload_triggers_refetch() {
+		set_transient(
+			$this->get_transient_key(),
+			array( 'gutenberg' => array( 'legacy-site' => array() ) ),
+			12 * HOUR_IN_SECONDS
+		);
+
+		$this->mock_api( array( 'gutenberg' => array( 'new-site' => array() ) ) );
+
+		$sites = $this->get_sites();
+
+		$this->assertArrayHasKey( 'new-site', $sites['gutenberg'] );
+		$this->assertSame( 1, $this->remote_calls );
+	}
+}


### PR DESCRIPTION
This pull request improves the caching mechanism for the `Sites_Listing` class and refactors how HTML entities are decoded in the onboarding UI. The caching changes make the cache more robust against external cleanup tools and ensure that stale or legacy cache entries do not get served indefinitely. Additionally, the decoding logic for HTML entities is centralized and reused across components. Unit tests are added to verify the new caching behavior.

### Caching improvements in `Sites_Listing`:

* The transient cache key is now version-stamped with `TIOB_VERSION` to ensure cache is invalidated on plugin updates.
* The cache payload now includes a `fetched_at` timestamp and is wrapped in an array, allowing the code to verify freshness independently of the transient's expiration. The new `get_cached_sites` method checks this timestamp before serving cached data.
* Legacy and stale cache payloads are detected and trigger a fresh fetch instead of being served.
* Comprehensive unit tests are added to verify version-stamping, cache wrapping, cache serving, and refetching logic.

### Frontend improvements:

* The `decodeHtmlEntities` utility is moved to a shared location (`onboarding/src/utils/common.js`) and reused in both `FeaturesList.js` and `StarterSiteCard.js`, ensuring consistent and maintainable decoding of HTML entities in UI labels. [[1]](diffhunk://#diff-2eafe1348fbc356d7b68fdd6a7fc03044938f92276d017596f1da9e95ff37bd6R54-R67) [[2]](diffhunk://#diff-614a4928189ff7294e26a4ecb35ca86cedc6dd8977ba12c60dbf15d28d901e0aR3-L11) [[3]](diffhunk://#diff-99db86f81a7442424b1f477e7df1114ed23691b9629f4458f2093158df9719f4R7) [[4]](diffhunk://#diff-99db86f81a7442424b1f477e7df1114ed23691b9629f4458f2093158df9719f4L80-R81)