### PR TITLE
Improved error handling for WXR file parsing

### DIFF
--- a/includes/Importers/WP/WXR_Parser_SimpleXML.php
+++ b/includes/Importers/WP/WXR_Parser_SimpleXML.php
@@ -22,7 +22,17 @@ class WXR_Parser_SimpleXML {
 		if ( \PHP_VERSION_ID < 80000 && function_exists( 'libxml_disable_entity_loader' ) ) {
 			$old_value = libxml_disable_entity_loader( true );
 		}
-		$success = $dom->loadXML( $wp_filesystem->get_contents( $file ) );
+
+		if ( ! $wp_filesystem->exists( $file ) ) {
+			return new WP_Error( 'SimpleXML_parse_error', 'The specified WXR file does not exist' );
+		}
+
+		$contents = $wp_filesystem->get_contents( $file );
+		if ( empty( $contents ) ) {
+			return new WP_Error( 'SimpleXML_parse_error', 'There was an error when reading this WXR file' );
+		}
+
+		$success = $dom->loadXML( $contents );
 		if ( ! is_null( $old_value ) ) {
 			libxml_disable_entity_loader( $old_value );
 		}

--- a/includes/Importers/WP/WXR_Parser_SimpleXML.php
+++ b/includes/Importers/WP/WXR_Parser_SimpleXML.php
@@ -15,13 +15,6 @@ class WXR_Parser_SimpleXML {
 	public function parse( $file ) {
 		global $wp_filesystem;
 		WP_Filesystem();
-		$authors         = $posts = $categories = $tags = $terms = array();
-		$internal_errors = libxml_use_internal_errors( true );
-		$dom             = new \DOMDocument;
-		$old_value       = null;
-		if ( \PHP_VERSION_ID < 80000 && function_exists( 'libxml_disable_entity_loader' ) ) {
-			$old_value = libxml_disable_entity_loader( true );
-		}
 
 		if ( ! $wp_filesystem->exists( $file ) ) {
 			return new WP_Error( 'SimpleXML_parse_error', 'The specified WXR file does not exist' );
@@ -30,6 +23,14 @@ class WXR_Parser_SimpleXML {
 		$contents = $wp_filesystem->get_contents( $file );
 		if ( empty( $contents ) ) {
 			return new WP_Error( 'SimpleXML_parse_error', 'There was an error when reading this WXR file' );
+		}
+
+		$authors         = $posts = $categories = $tags = $terms = array();
+		$internal_errors = libxml_use_internal_errors( true );
+		$dom             = new \DOMDocument;
+		$old_value       = null;
+		if ( \PHP_VERSION_ID < 80000 && function_exists( 'libxml_disable_entity_loader' ) ) {
+			$old_value = libxml_disable_entity_loader( true );
 		}
 
 		$success = $dom->loadXML( $contents );


### PR DESCRIPTION
### Summary
Checked that the WXR file exists and is valid. If not, then return an error message instead of proceeding with the import to prevent a fatal error.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/templates-patterns-collection/issues/491