### PR TITLE
Release

### DIFF
--- a/includes/Importers/WP/WXR_Parser_SimpleXML.php
+++ b/includes/Importers/WP/WXR_Parser_SimpleXML.php
@@ -22,7 +22,17 @@ class WXR_Parser_SimpleXML {
 		if ( \PHP_VERSION_ID < 80000 && function_exists( 'libxml_disable_entity_loader' ) ) {
 			$old_value = libxml_disable_entity_loader( true );
 		}
-		$success = $dom->loadXML( $wp_filesystem->get_contents( $file ) );
+
+		if ( ! $wp_filesystem->exists( $file ) ) {
+			return new WP_Error( 'SimpleXML_parse_error', 'The specified WXR file does not exist' );
+		}
+
+		$contents = $wp_filesystem->get_contents( $file );
+		if ( empty( $contents ) ) {
+			return new WP_Error( 'SimpleXML_parse_error', 'There was an error when reading this WXR file' );
+		}
+
+		$success = $dom->loadXML( $contents );
 		if ( ! is_null( $old_value ) ) {
 			libxml_disable_entity_loader( $old_value );
 		}

--- a/includes/Importers/WP/WXR_Parser_SimpleXML.php
+++ b/includes/Importers/WP/WXR_Parser_SimpleXML.php
@@ -15,13 +15,6 @@ class WXR_Parser_SimpleXML {
 	public function parse( $file ) {
 		global $wp_filesystem;
 		WP_Filesystem();
-		$authors         = $posts = $categories = $tags = $terms = array();
-		$internal_errors = libxml_use_internal_errors( true );
-		$dom             = new \DOMDocument;
-		$old_value       = null;
-		if ( \PHP_VERSION_ID < 80000 && function_exists( 'libxml_disable_entity_loader' ) ) {
-			$old_value = libxml_disable_entity_loader( true );
-		}
 
 		if ( ! $wp_filesystem->exists( $file ) ) {
 			return new WP_Error( 'SimpleXML_parse_error', 'The specified WXR file does not exist' );
@@ -30,6 +23,14 @@ class WXR_Parser_SimpleXML {
 		$contents = $wp_filesystem->get_contents( $file );
 		if ( empty( $contents ) ) {
 			return new WP_Error( 'SimpleXML_parse_error', 'There was an error when reading this WXR file' );
+		}
+
+		$authors         = $posts = $categories = $tags = $terms = array();
+		$internal_errors = libxml_use_internal_errors( true );
+		$dom             = new \DOMDocument;
+		$old_value       = null;
+		if ( \PHP_VERSION_ID < 80000 && function_exists( 'libxml_disable_entity_loader' ) ) {
+			$old_value = libxml_disable_entity_loader( true );
 		}
 
 		$success = $dom->loadXML( $contents );


### PR DESCRIPTION
This PR merges the latest changes from `development` into `master`.

### Linked issues
<!-- linked-issues:start -->
This release will close the following issues once merged:

- Closes #491 — WXR parser fatal `DOMDocument::loadXML(): Argument #1 ($source) must not be empty`
<!-- linked-issues:end -->

### Public changelog
<!-- public-changelog:start -->
- Fixed a fatal error that could occur during site import when the import file was missing or empty; a clear error message is now shown instead.
<!-- public-changelog:end -->
