### PR TITLE
Improve starter search responsiveness

### DIFF
--- a/includes/Starter_Ranking.php
+++ b/includes/Starter_Ranking.php
@@ -15,7 +15,7 @@ class Starter_Ranking {
 	const DEFAULT_BASE   = 'https://ai.themeisle.com';
 	const SLUG           = 'neve-starter-ranking';
 	const VERSION        = 'v3';
-	const CACHE_TTL      = HOUR_IN_SECONDS;
+	const CACHE_TTL      = 7 * DAY_IN_SECONDS;
 	const REQUEST_BUDGET = 6;
 	const SEARCH_BUDGET  = 8;
 

--- a/includes/Starter_Ranking.php
+++ b/includes/Starter_Ranking.php
@@ -14,8 +14,8 @@ class Starter_Ranking {
 
 	const DEFAULT_BASE   = 'https://ai.themeisle.com';
 	const SLUG           = 'neve-starter-ranking';
-	const VERSION        = 'v2';
-	const CACHE_TTL      = 7 * DAY_IN_SECONDS;
+	const VERSION        = 'v3';
+	const CACHE_TTL      = HOUR_IN_SECONDS;
 	const REQUEST_BUDGET = 6;
 	const SEARCH_BUDGET  = 8;
 

--- a/onboarding/src/Components/Sites.js
+++ b/onboarding/src/Components/Sites.js
@@ -7,13 +7,13 @@ import { matchesCategory, searchCatalog } from '../utils/search';
 
 /**
  * @typedef {Object} Site
- * @property {string}   url
- * @property {string}   remote_url
- * @property {string}   screenshot
- * @property {string}   title
- * @property {string[]} keywords
- * @property {boolean}  isNew
- * @property {string}   slug
+ * @property {string}   url        Local preview URL.
+ * @property {string}   remote_url Remote demo URL.
+ * @property {string}   screenshot Starter-site screenshot URL.
+ * @property {string}   title      Display title.
+ * @property {string[]} keywords   Search keywords.
+ * @property {boolean}  isNew      Whether the starter site is newly added.
+ * @property {string}   slug       Unique starter-site slug.
  */
 
 const Sites = ( {
@@ -147,15 +147,21 @@ const Sites = ( {
 			return items;
 		}
 
+		const localMatches = searchCatalog( items, searchQuery );
+
 		if ( Array.isArray( searchOrder ) && searchOrder.length ) {
-			return pickBySlugs( items, searchOrder ).picked;
+			const { picked, placed } = pickBySlugs( items, searchOrder );
+			localMatches.forEach( ( site ) => {
+				if ( site?.slug && ! placed[ site.slug ] ) {
+					placed[ site.slug ] = true;
+					picked.push( site );
+				}
+			} );
+
+			return picked;
 		}
 
-		if ( searchFailed ) {
-			return searchCatalog( items, searchQuery );
-		}
-
-		return [];
+		return localMatches;
 	};
 
 	const filterByCategory = ( items, cat ) => {

--- a/onboarding/src/Components/Steps/SiteList.js
+++ b/onboarding/src/Components/Steps/SiteList.js
@@ -18,7 +18,7 @@ const { onboarding } = tiobDash;
 
 // Debounce the search so it stays off the network while typing: only fire after the
 // field is idle for SEARCH_DEBOUNCE_MS and the query is at least SEARCH_MIN_CHARS.
-const SEARCH_DEBOUNCE_MS = 700;
+const SEARCH_DEBOUNCE_MS = 1500;
 const SEARCH_MIN_CHARS = 3;
 
 // Guards tracking-session init against firing twice while the first request is in flight.
@@ -49,6 +49,10 @@ const SiteList = ( {
 					href={ tiobDash.onboardingUpsell.upgradeToast }
 					target="_blank"
 					rel="noopener noreferrer"
+					aria-label={ __(
+						'View Neve Business plans',
+						'templates-patterns-collection'
+					) }
 				/>
 			),
 		}


### PR DESCRIPTION
## What changed

- increase semantic-search debounce from 700ms to 1.5 seconds
- keep the existing three-character minimum
- show local catalog matches immediately while semantic search is pending
- place semantic matches first, then append de-duplicated local matches
- bump the local cache version once while keeping the existing seven-day cache duration

## Why

The longer debounce reduces superseded requests while immediate local results keep the interface responsive. The local fallback also prevents a narrow semantic response from hiding an exact catalog match.

The corresponding Agents change is [Codeinwp/agents#168](https://github.com/Codeinwp/agents/pull/168).

## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code for style and quality.
- [x] I have updated docs/changelog if needed.
