### PR TITLE
Validated Neve license plans correctly

### DIFF
--- a/assets/src/Components/CloudLibrary/common.js
+++ b/assets/src/Components/CloudLibrary/common.js
@@ -7,6 +7,7 @@ import { models, loadPromise } from '@wordpress/api';
 import { cleanTemplateContent } from '../../../../shared/utils';
 import {
 	isLicenseValid,
+	isTemplatesCloudTier,
 } from '../../../../shared/utils';
 
 export const changeOption = ( option, value ) => {
@@ -96,7 +97,7 @@ export const licenseCheck = async ( licenseKey ) => {
 			license_check: 1,
 		} ) ) || {};
 
-	if ( ! success || ! isLicenseValid( license ) ) {
+	if ( ! success || ! isLicenseValid( license ) || ! isTemplatesCloudTier( license?.tier ) ) {
 		return {
 			success: false,
 			status: 'invalid',

--- a/assets/src/Components/CloudLibrary/common.js
+++ b/assets/src/Components/CloudLibrary/common.js
@@ -5,6 +5,9 @@ import { stringifyUrl } from 'query-string';
 import { v4 as uuidv4 } from 'uuid';
 import { models, loadPromise } from '@wordpress/api';
 import { cleanTemplateContent } from '../../../../shared/utils';
+import {
+	isLicenseValid,
+} from '../../../../shared/utils';
 
 export const changeOption = ( option, value ) => {
 	const model = new models.Settings( {
@@ -78,6 +81,31 @@ export const fetchLibrary = async (
 			return { success: false, message: error.message };
 		}
 	}
+};
+
+/**
+ * Validate a license key against the licensing API.
+ *
+ * @param {string} licenseKey The license key to check.
+ * @return {Promise<Object>} `{ success, status, license, message }`.
+ */
+export const licenseCheck = async ( licenseKey ) => {
+	const { success, templates: license, message } =
+		( await fetchLibrary( false, {
+			license_id: licenseKey,
+			license_check: 1,
+		} ) ) || {};
+
+	if ( ! success || ! isLicenseValid( license ) ) {
+		return {
+			success: false,
+			status: 'invalid',
+			license,
+			message,
+		};
+	}
+
+	return { success: true, status: 'valid', license };
 };
 
 export const updateTemplate = async ( id, name ) => {

--- a/assets/src/Components/CloudLibrary/common.js
+++ b/assets/src/Components/CloudLibrary/common.js
@@ -4,11 +4,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { stringifyUrl } from 'query-string';
 import { v4 as uuidv4 } from 'uuid';
 import { models, loadPromise } from '@wordpress/api';
-import { cleanTemplateContent } from '../../../../shared/utils';
-import {
-	isLicenseValid,
-	isTemplatesCloudTier,
-} from '../../../../shared/utils';
+import { cleanTemplateContent, hasTemplatesCloudAccess } from '../../../../shared/utils';
 
 export const changeOption = ( option, value ) => {
 	const model = new models.Settings( {
@@ -97,7 +93,7 @@ export const licenseCheck = async ( licenseKey ) => {
 			license_check: 1,
 		} ) ) || {};
 
-	if ( ! success || ! isLicenseValid( license ) || ! isTemplatesCloudTier( license?.tier ) ) {
+	if ( ! success || ! hasTemplatesCloudAccess( license ) ) {
 		return {
 			success: false,
 			status: 'invalid',

--- a/assets/src/Components/Header.js
+++ b/assets/src/Components/Header.js
@@ -17,7 +17,6 @@ const TabNavigation = ( {
 	setCurrentTab,
 	currentTab,
 	isFetching,
-	license,
 } ) => {
 	const buttons = {};
 
@@ -33,7 +32,6 @@ const TabNavigation = ( {
 
 	const [ isSyncing, setSyncing ] = useState( false );
 	const { isLicenseOpen, setLicenseOpen } = useContext( LicensePanelContext );
-	const isValid = 'valid' === license?.valid || 'valid' === license?.license;
 
 	const sync = () => {
 		setSyncing( true );
@@ -158,7 +156,6 @@ const Header = ( {
 	cancelOnboarding,
 	setCurrentTab,
 	currentTab,
-	license,
 } ) => {
 	return (
 		<div className="ob-head">
@@ -169,7 +166,6 @@ const Header = ( {
 						<TabNavigation
 							setCurrentTab={ setCurrentTab }
 							currentTab={ currentTab }
-							license={ license }
 						/>
 					</div>
 				</>
@@ -204,13 +200,11 @@ export default compose(
 			getOnboardingStatus,
 			getCurrentTab,
 			getFetching,
-			getLicense,
 		} = select( 'neve-onboarding' );
 		return {
 			isOnboarding: getOnboardingStatus(),
 			currentTab: getCurrentTab(),
 			isFetching: getFetching(),
-			license: getLicense(),
 		};
 	} )
 )( Header );

--- a/assets/src/Components/License.js
+++ b/assets/src/Components/License.js
@@ -61,7 +61,7 @@ const License = ( { setLicense, license } ) => {
 			return;
 		}
 
-		const { success, status, license: licenseData } = await licenseCheck( data.key );
+		const { success, license: licenseData } = await licenseCheck( data.key );
 
 		if ( success ) {
 			setLicense( licenseData );

--- a/assets/src/Components/License.js
+++ b/assets/src/Components/License.js
@@ -1,3 +1,4 @@
+/* global tiobDash */
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
@@ -12,7 +13,10 @@ import {
 } from '@wordpress/components';
 import { models } from '@wordpress/api';
 import { licenseCheck } from './CloudLibrary/common';
-import { isLicenseValid, isTemplatesCloudTier } from '../../../shared/utils';
+import {
+	hasTemplatesCloudAccess,
+	isLicenseValid,
+} from '../../../shared/utils';
 
 const License = ( { setLicense, license } ) => {
 	const keyValue = license?.key !== '' && license?.key !== 'free' ? license?.key : '';
@@ -20,7 +24,13 @@ const License = ( { setLicense, license } ) => {
 	const [ loading, setLoading ] = useState( false );
 	const [ resultMsg, setResultMsg ] = useState( {} );
 
-	const isValid = isLicenseValid( license ) && isTemplatesCloudTier( license?.tier );
+	const isStored = isLicenseValid( license );
+	const hasAccess = hasTemplatesCloudAccess( license );
+
+	const notEntitledMsg = __(
+		'Your license is valid, but Templates Cloud is not included in your plan.',
+		'templates-patterns-collection'
+	);
 
 	const delay = (time) => new Promise(resolve => setTimeout(resolve, time));
 
@@ -77,7 +87,7 @@ const License = ( { setLicense, license } ) => {
 
 	const toggleLicense = ( event ) => {
 		onSaveLicense( {
-			action: isValid ? 'deactivate' : 'activate',
+			action: isStored ? 'deactivate' : 'activate',
 			key: licenseKey,
 		} );
 
@@ -85,9 +95,9 @@ const License = ( { setLicense, license } ) => {
 	};
 
 	const futureDate = new Date( new Date().setFullYear( new Date().getFullYear() + 10 ) );
-	const expiration = isValid && license?.expires === 'lifetime' ? futureDate.toDateString() : new Date( license.expires ).toDateString();
+	const expiration = isStored && license?.expires === 'lifetime' ? futureDate.toDateString() : new Date( license.expires ).toDateString();
 
-	const licenseStatusMsg = isValid ? (
+	const licenseStatusMsg = hasAccess ? (
 		<>
 			<Icon size={ 24 } className="verified" icon="yes-alt" />
 			<span>{ 'Verified - Expires at'} { expiration }</span>
@@ -96,6 +106,18 @@ const License = ( { setLicense, license } ) => {
 	) : (
 		''
 	);
+
+	const renderEntitlementMsg =
+		isStored && ! hasAccess ? (
+			<Notice isDismissible={ false } status="warning">
+				{ notEntitledMsg }{ ' ' }
+				<ExternalLink href={ tiobDash.upgradeURLTpc }>
+					{ __( 'Upgrade to PRO', 'templates-patterns-collection' ) }
+				</ExternalLink>
+			</Notice>
+		) : (
+			''
+		);
 
 	const renderResultMsg =
 		Object.keys( resultMsg ).length > 0 ? (
@@ -110,11 +132,11 @@ const License = ( { setLicense, license } ) => {
 		<>
 			<form className="license-form" onSubmit={ toggleLicense }>
 				<TextControl
-					disabled={ isValid }
+					disabled={ isStored }
 					onChange={ setLicenseKey }
 					label={ __( 'License Key', 'templates-patterns-collection' ) }
 					value={
-						isValid
+						isStored
 							? '******************************' +
 							  licenseKey.slice( -5 )
 							: licenseKey
@@ -126,13 +148,14 @@ const License = ( { setLicense, license } ) => {
 					type="submit"
 					variant="primary"
 				>
-					{ isValid
+					{ isStored
 						? __( 'Deactivate', 'templates-patterns-collection' )
 						: __( 'Activate', 'templates-patterns-collection' ) }
 				</Button>
 			</form>
 
 			<div className="info">{ licenseStatusMsg }</div>
+			{ renderEntitlementMsg }
 			{ renderResultMsg }
 		</>
 	);

--- a/assets/src/Components/License.js
+++ b/assets/src/Components/License.js
@@ -11,7 +11,8 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { models } from '@wordpress/api';
-import { fetchLibrary as licenseCheck } from './CloudLibrary/common';
+import { licenseCheck } from './CloudLibrary/common';
+import { isLicenseValid, isTemplatesCloudTier } from '../../../shared/utils';
 
 const License = ( { setLicense, license } ) => {
 	const keyValue = license?.key !== '' && license?.key !== 'free' ? license?.key : '';
@@ -19,8 +20,7 @@ const License = ( { setLicense, license } ) => {
 	const [ loading, setLoading ] = useState( false );
 	const [ resultMsg, setResultMsg ] = useState( {} );
 
-
-	const isValid = 'valid' === license?.valid || 'valid' === license?.license;
+	const isValid = isLicenseValid( license ) && isTemplatesCloudTier( license?.tier );
 
 	const delay = (time) => new Promise(resolve => setTimeout(resolve, time));
 
@@ -61,10 +61,10 @@ const License = ( { setLicense, license } ) => {
 			return;
 		}
 
-		const { success, templates } = await licenseCheck( false, { license_id: data.key, license_check: 1 } );
+		const { success, status, license: licenseData } = await licenseCheck( data.key );
 
 		if ( success ) {
-			setLicense( templates );
+			setLicense( licenseData );
 			await updateKey( data.key );
 		} else {
 			createNotice(

--- a/assets/src/store/selectors.js
+++ b/assets/src/store/selectors.js
@@ -1,3 +1,5 @@
+import { isTemplatesCloudTier } from '../../../shared/utils';
+
 export default {
 	getSites: ( state ) => state.sites,
 	getMigrationData: ( state ) => state.migrationData,
@@ -15,28 +17,10 @@ export default {
 	getTemplateModal: ( state ) => state.templateModal,
 	getSearchQuery: ( state ) => state.searchQuery,
 	getUserStatus: ( state ) => {
-		const acceptedTiers = [
-			6,
-			17,
-			23,
-			5,
-			9,
-			14,
-			20,
-			1,
-			7,
-			12,
-			18,
-			3,
-			8,
-			13,
-			19,
-		];
-
 		return (
 			state.license &&
 			state.license.tier &&
-			acceptedTiers.includes( state.license.tier )
+			isTemplatesCloudTier( state.license.tier )
 		);
 	},
 	getLicense: ( state ) => {

--- a/e2e-tests/config/mocks.js
+++ b/e2e-tests/config/mocks.js
@@ -108,6 +108,23 @@ export const MOCK_TEMPLATES = [
     },
 ];
 
+// License payloads returned for a browser-side license check (license_check=1).
+// AGENCY_LICENSE matches the license the mu-plugin seeds; PERSONAL_LICENSE is a
+// valid license on a tier that does not include Templates Cloud.
+export const AGENCY_LICENSE = {
+    license: 'valid',
+    key: 'tpc-e2e-key',
+    tier: 3,
+    expires: 'lifetime',
+};
+
+export const PERSONAL_LICENSE = {
+    license: 'valid',
+    key: 'tpc-e2e-personal-key',
+    tier: 2,
+    expires: 'lifetime',
+};
+
 // apiFetch sends credentialed requests, so the mocked cross-origin responses
 // must echo the exact origin (a wildcard is rejected by the browser).
 const corsHeaders = (route) => ({
@@ -142,9 +159,19 @@ export async function mockOnboardingRoutes(page) {
 export const TEMPLATE_CONTENT_TEXT = 'TPC E2E imported content';
 export const TEMPLATE_CONTENT = `<!-- wp:paragraph --><p>${TEMPLATE_CONTENT_TEXT}</p><!-- /wp:paragraph -->`;
 
-export async function mockTemplatesCloudRoutes(page, templates = MOCK_TEMPLATES) {
+export async function mockTemplatesCloudRoutes(
+    page,
+    templates = MOCK_TEMPLATES,
+    license = AGENCY_LICENSE,
+) {
     await page.route('**/api.themeisle.com/templates-cloud/**', (route) => {
         const url = new URL(route.request().url());
+
+        // license_check=1 returns the license data instead of templates - this
+        // is what the license panel activates against.
+        if (url.searchParams.get('license_check')) {
+            return fulfillJson(route, license);
+        }
 
         // GET templates/{id}/import returns the template's block content.
         if (url.pathname.endsWith('/import')) {

--- a/e2e-tests/mu-plugins/tpc-e2e.php
+++ b/e2e-tests/mu-plugins/tpc-e2e.php
@@ -62,7 +62,7 @@ add_action(
 				'args'                => array(
 					'mode' => array(
 						'type' => 'string',
-						'enum' => array( '', 'down', 'invalid' ),
+						'enum' => array( '', 'down', 'invalid', 'personal' ),
 					),
 				),
 				'callback'            => function ( $request ) {
@@ -110,9 +110,11 @@ add_filter(
 		$is_themeisle_api = false !== strpos( $url, 'api.themeisle.com' ) || false !== strpos( $url, 'ai.themeisle.com' );
 
 		// Scenario modes (Otter pattern), set per spec via tpc-e2e/v1/api-mode:
-		// 'down'    => ThemeIsle APIs unreachable.
-		// 'invalid' => license check rejects the key (a code/message body is
-		//              what License::check_license treats as invalid).
+		// 'down'     => ThemeIsle APIs unreachable.
+		// 'invalid'  => license check rejects the key (a code/message body is
+		//               what License::check_license treats as invalid).
+		// 'personal' => the key is accepted, on a tier that does not include
+		//               Templates Cloud.
 		$mode = get_option( 'tpc_e2e_api_mode', '' );
 
 		if ( 'down' === $mode && $is_themeisle_api ) {
@@ -125,6 +127,21 @@ add_filter(
 					array(
 						'code'    => 'invalid_license',
 						'message' => 'TPC E2E: invalid license.',
+					)
+				)
+			);
+		}
+
+		// A valid license on a tier that does not include Templates Cloud.
+		// Must match PERSONAL_LICENSE in config/mocks.js.
+		if ( 'personal' === $mode && false !== strpos( $url, 'api.themeisle.com/templates-cloud/' ) ) {
+			return tpc_e2e_response(
+				wp_json_encode(
+					array(
+						'license' => 'valid',
+						'key'     => 'tpc-e2e-personal-key',
+						'tier'    => 2,
+						'expires' => 'lifetime',
 					)
 				)
 			);

--- a/e2e-tests/specs/license.spec.js
+++ b/e2e-tests/specs/license.spec.js
@@ -71,3 +71,43 @@ test.describe('License activation', () => {
         await expect(page.getByRole('button', { name: 'Deactivate' })).toBeVisible();
     });
 });
+
+// The 'personal' API mode is the state inherit_license_from_neve() stores for a
+// Neve Personal key: the license is valid, its tier is not eligible. The panel
+// has to treat it as a stored license and still say why Templates Cloud is locked.
+test.describe('A stored license on an ineligible plan', () => {
+    const SETTINGS_URL = 'admin.php?page=tiob-plugin#settings';
+
+    test.beforeEach(async ({ requestUtils, admin }) => {
+        await setLegacyTc(requestUtils, true);
+        await setApiMode(requestUtils, 'personal');
+        await admin.visitAdminPage(SETTINGS_URL);
+    });
+
+    test.afterEach(async ({ requestUtils }) => {
+        await setApiMode(requestUtils, '');
+        await setLegacyTc(requestUtils, false);
+    });
+
+    test('can be deactivated', async ({ page }) => {
+        await expect(page.getByRole('button', { name: 'Deactivate' })).toBeVisible();
+    });
+
+    test('is masked in the license field', async ({ page }) => {
+        await expect(page.getByLabel('License Key')).toHaveValue(
+            '******************************l-key',
+        );
+    });
+
+    test('is not reported as verified', async ({ page }) => {
+        await expect(page.getByText('Verified - Expires at')).toBeHidden();
+    });
+
+    test('explains that the plan does not include Templates Cloud', async ({ page }) => {
+        await expect(
+            page.getByText(
+                'Your license is valid, but Templates Cloud is not included in your plan.',
+            ),
+        ).toBeVisible();
+    });
+});

--- a/e2e-tests/specs/license.spec.js
+++ b/e2e-tests/specs/license.spec.js
@@ -54,9 +54,7 @@ test.describe('License activation', () => {
         await page.getByRole('button', { name: 'Activate' }).click();
 
         await expect(
-            page.locator('.components-notice__content').filter({
-                hasText: 'Can not activate this license!'
-            })
+            page.locator('#tpc-app').getByText('Can not activate this license!', { exact: true })
         ).toBeVisible();
     });
 

--- a/e2e-tests/specs/license.spec.js
+++ b/e2e-tests/specs/license.spec.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import {
+    AGENCY_LICENSE,
+    MOCK_TEMPLATES,
+    PERSONAL_LICENSE,
+    mockTemplatesCloudRoutes,
+} from '../config/mocks';
+
+const setApiMode = (requestUtils, mode) =>
+    requestUtils.rest({
+        path: '/tpc-e2e/v1/api-mode',
+        method: 'POST',
+        data: { mode },
+    });
+
+const setLegacyTc = (requestUtils, enabled) =>
+    requestUtils.rest({
+        path: '/tpc-e2e/v1/legacy-tc',
+        method: 'POST',
+        data: { enabled },
+    });
+
+// The license panel lives in the tiob-plugin dashboard settings, which only
+// exists for "legacy Templates Cloud" installs. The 'invalid' API mode drops the
+// license the mu-plugin seeds, so the activation form is the starting state.
+test.describe('License activation', () => {
+    const SETTINGS_URL = 'admin.php?page=tiob-plugin#settings';
+
+    test.beforeEach(async ({ requestUtils }) => {
+        await setLegacyTc(requestUtils, true);
+        await setApiMode(requestUtils, 'invalid');
+    });
+
+    test.afterEach(async ({ requestUtils }) => {
+        await setApiMode(requestUtils, '');
+        await setLegacyTc(requestUtils, false);
+    });
+
+    test('not activating a personal plan', async ({
+        page,
+        admin,
+    }) => {
+        await mockTemplatesCloudRoutes(page, MOCK_TEMPLATES, PERSONAL_LICENSE);
+        await admin.visitAdminPage(SETTINGS_URL);
+
+        await page.getByLabel('License Key').fill(PERSONAL_LICENSE.key);
+        await page.getByRole('button', { name: 'Activate' }).click();
+
+        await expect(
+            page.locator('.components-notice__content').filter({
+                hasText: 'Can not activate this license!'
+            })
+        ).toBeVisible();
+    });
+
+    test('activating an agency plan', async ({
+        page,
+        admin,
+    }) => {
+        await mockTemplatesCloudRoutes(page, MOCK_TEMPLATES, AGENCY_LICENSE);
+        await admin.visitAdminPage(SETTINGS_URL);
+
+        await page.getByLabel('License Key').fill(AGENCY_LICENSE.key);
+        await page.getByRole('button', { name: 'Activate' }).click();
+
+        await expect(page.getByRole('button', { name: 'Deactivate' })).toBeVisible();
+    });
+});

--- a/e2e-tests/specs/license.spec.js
+++ b/e2e-tests/specs/license.spec.js
@@ -43,7 +43,7 @@ test.describe('License activation', () => {
         await setLegacyTc(requestUtils, false);
     });
 
-    test('not activating a personal plan', async ({
+    test('not activating personal plan', async ({
         page,
         admin,
     }) => {

--- a/onboarding/src/store/selectors.js
+++ b/onboarding/src/store/selectors.js
@@ -1,3 +1,5 @@
+import { isTemplatesCloudTier } from '../../../shared/utils';
+
 export default {
 	getThemeAction: ( state ) => state.themeAction,
 	getCurrentStep: ( state ) => state.onboardingStep,
@@ -11,14 +13,10 @@ export default {
 	getError: ( state ) => state.error,
 	getPluginOptions: ( state ) => state.pluginOptions,
 	getUserStatus: ( state ) => {
-		const acceptedTiers = [
-			6, 17, 23, 5, 9, 14, 20, 1, 7, 12, 18, 3, 8, 13, 19,
-		];
-
 		return (
 			state.license &&
 			state.license.tier &&
-			acceptedTiers.includes( state.license.tier )
+			isTemplatesCloudTier( state.license.tier )
 		);
 	},
 	getUserCustomSettings: ( state ) => state.userCustomSettings,

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -65,3 +65,12 @@ export const isTemplatesCloudTier = ( tier ) => {
  */
 export const isLicenseValid = ( license ) =>
 	'valid' === license?.valid || 'valid' === license?.license;
+
+/**
+ * Check if the license grants access to Templates Cloud.
+ *
+ * @param {Object} license The license data.
+ * @return {boolean} Whether the license is valid and includes Templates Cloud.
+ */
+export const hasTemplatesCloudAccess = ( license ) =>
+	isLicenseValid( license ) && isTemplatesCloudTier( license?.tier );

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -23,3 +23,45 @@ export const cleanTemplateContent = ( templateContent, cleanFunc ) => {
 		loopElementorElement( item, cleanFunc );
 	} );
 };
+
+/**
+ * License tiers entitled to Templates Cloud.
+ */
+export const TEMPLATES_CLOUD_TIERS = [
+	6,
+	17,
+	23,
+	5,
+	9,
+	14,
+	20,
+	1,
+	7,
+	12,
+	18,
+	3,
+	8,
+	13,
+	19,
+];
+
+/**
+ * Check if a license tier is entitled to Templates Cloud.
+ *
+ * @param {number|string} tier The tier key returned by the licensing API.
+ * @return {boolean} Whether the tier includes Templates Cloud.
+ */
+export const isTemplatesCloudTier = ( tier ) => {
+	const parsed = Number( tier );
+
+	return Number.isInteger( parsed ) && TEMPLATES_CLOUD_TIERS.includes( parsed );
+};
+
+/**
+ * Check if the license itself is valid, regardless of its tier.
+ *
+ * @param {Object} license The license data.
+ * @return {boolean} Whether the license is valid.
+ */
+export const isLicenseValid = ( license ) =>
+	'valid' === license?.valid || 'valid' === license?.license;


### PR DESCRIPTION
### Summary
Validate the license tier before activating the license. If the license is valid but the plan does not include Templates Cloud, show a notice that the license cannot be activated.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/templates-patterns-collection/issues/501